### PR TITLE
Allow user certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:supportsRtl="true"
         android:fullBackupContent="@xml/full_backup_content"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.NextcloudPasswords"
         android:enableOnBackInvokedCallback="true"
         tools:ignore="UnusedAttribute">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config
+    xmlns:tools="http://schemas.android.com/tools">
+    <base-config>
+        <trust-anchors>
+            <certificates
+                src="system" />
+            <certificates
+                src="user"
+                tools:ignore="AcceptsUserCertificates" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Consider a self-sign SSL valid if the CA certificate is installed by the user to avoid WebView SSL Error.