### PR TITLE
Show password count per folder in the folder list (#79)

### DIFF
--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/ItemList.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/ItemList.kt
@@ -54,6 +54,17 @@ data class ListDecryptionState<T>(
     val isLoading: Boolean = false
 )
 
+/**
+ * Counts the visible (not hidden, not trashed) passwords per folder id, so a
+ * folder row can show how many passwords it directly contains. Counts direct
+ * children only, matching the passwords shown when the folder is opened.
+ */
+fun folderPasswordCounts(passwords: List<Password>): Map<String, Int> =
+    passwords.asSequence()
+        .filter { !it.hidden && !it.trashed }
+        .groupingBy { it.folder }
+        .eachCount()
+
 @Composable
 fun MixedLazyColumn(
     passwords: List<Password>? = null,
@@ -62,7 +73,8 @@ fun MixedLazyColumn(
     onPasswordLongClick: ((Password) -> Unit)? = null,
     onFolderClick: ((Folder) -> Unit)? = null,
     onFolderLongClick: ((Folder) -> Unit)? = null,
-    getPainterForUrl: (@Composable (String) -> Painter)? = null
+    getPainterForUrl: (@Composable (String) -> Painter)? = null,
+    folderPasswordCounts: Map<String, Int>? = null
 ) {
     val context = LocalContext.current
     val shouldShowIcon by PreferencesManager.getInstance(context).getShowIcons()
@@ -89,6 +101,7 @@ fun MixedLazyColumn(
             items(items = it, key = { folder -> folder.id }) { folder ->
                 FolderRow(
                     folder = folder,
+                    passwordCount = folderPasswordCounts?.let { it[folder.id] ?: 0 },
                     onFolderClick = onFolderClick,
                     onFolderLongClick = onFolderLongClick
                 )
@@ -179,6 +192,7 @@ fun PasswordRow(
 fun FolderRow(
     folder: Folder,
     modifier: Modifier = Modifier,
+    passwordCount: Int? = null,
     onFolderClick: ((Folder) -> Unit)? = null,
     onFolderLongClick: ((Folder) -> Unit)? = null,
 ) {
@@ -195,6 +209,15 @@ fun FolderRow(
         },
         headlineContent = {
             Text(text = folder.label)
+        },
+        trailingContent = passwordCount?.let { count ->
+            {
+                Text(
+                    text = count.toString(),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         },
         modifier = modifier
             .combinedClickable(

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
@@ -315,6 +315,9 @@ fun NCPNavHost(
                                 it.parent == FoldersApi.DEFAULT_FOLDER_UUID
                             }
                         }
+                        val folderPasswordCounts = remember(passwordsDecryptionState.decryptedList) {
+                            folderPasswordCounts(passwordsDecryptionState.decryptedList ?: emptyList())
+                        }
                         when {
                             foldersDecryptionState.isLoading || passwordsDecryptionState.isLoading -> {
                                 Box(modifier = Modifier.fillMaxSize()) {
@@ -343,6 +346,7 @@ fun NCPNavHost(
                                         MixedLazyColumn(
                                             passwords = filteredPasswordsParentFolder,
                                             folders = filteredFoldersParentFolder,
+                                            folderPasswordCounts = folderPasswordCounts,
                                             onPasswordClick = onPasswordClick,
                                             onPasswordLongClick = {
                                                 if (sessionOpen && (autofillData == null || autofillData.isSave()) && it.editable)
@@ -381,6 +385,9 @@ fun NCPNavHost(
                         filteredFolderList?.filter {
                             it.parent == folderUuid
                         }
+                    }
+                    val folderPasswordCounts = remember(passwordsDecryptionState.decryptedList) {
+                        folderPasswordCounts(passwordsDecryptionState.decryptedList ?: emptyList())
                     }
                     NCPNavHostComposable(
                         modalSheetState = modalSheetState,
@@ -421,6 +428,7 @@ fun NCPNavHost(
                                         MixedLazyColumn(
                                             passwords = filteredPasswordsSelectedFolder,
                                             folders = filteredFoldersSelectedFolder,
+                                            folderPasswordCounts = folderPasswordCounts,
                                             onPasswordClick = onPasswordClick,
                                             onPasswordLongClick = {
                                                 if (sessionOpen && (autofillData == null || autofillData.isSave()) && it.editable)

--- a/app/src/test/java/com/hegocre/nextcloudpasswords/FolderPasswordCountTest.kt
+++ b/app/src/test/java/com/hegocre/nextcloudpasswords/FolderPasswordCountTest.kt
@@ -1,0 +1,95 @@
+package com.hegocre.nextcloudpasswords
+
+import com.hegocre.nextcloudpasswords.data.password.Password
+import com.hegocre.nextcloudpasswords.ui.components.folderPasswordCounts
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for the per-folder password counting used by the folder list.
+ */
+class FolderPasswordCountTest {
+    private fun password(
+        id: String,
+        folder: String,
+        hidden: Boolean = false,
+        trashed: Boolean = false
+    ) = Password(
+        id = id,
+        label = id,
+        username = "",
+        password = "",
+        url = "",
+        notes = "",
+        customFields = "",
+        status = 0,
+        statusCode = "GOOD",
+        hash = "",
+        folder = folder,
+        revision = "",
+        share = null,
+        shared = false,
+        cseType = "",
+        cseKey = "",
+        sseType = "",
+        client = "",
+        hidden = hidden,
+        trashed = trashed,
+        favorite = false,
+        editable = true,
+        edited = 0,
+        created = 0,
+        updated = 0
+    )
+
+    private val folderA = "folder-a"
+    private val folderB = "folder-b"
+
+    @Test
+    fun countsPasswordsPerFolder() {
+        val counts = folderPasswordCounts(
+            listOf(
+                password("1", folderA),
+                password("2", folderA),
+                password("3", folderB)
+            )
+        )
+        assertEquals(2, counts[folderA])
+        assertEquals(1, counts[folderB])
+    }
+
+    @Test
+    fun folderWithoutPasswordsIsAbsent() {
+        val counts = folderPasswordCounts(listOf(password("1", folderA)))
+        assertNull(counts["empty-folder"])
+    }
+
+    @Test
+    fun emptyListYieldsEmptyMap() {
+        assertEquals(emptyMap<String, Int>(), folderPasswordCounts(emptyList()))
+    }
+
+    @Test
+    fun hiddenAndTrashedPasswordsAreExcluded() {
+        val counts = folderPasswordCounts(
+            listOf(
+                password("1", folderA),
+                password("2", folderA, hidden = true),
+                password("3", folderA, trashed = true)
+            )
+        )
+        assertEquals(1, counts[folderA])
+    }
+
+    @Test
+    fun folderWithOnlyHiddenOrTrashedPasswordsIsAbsent() {
+        val counts = folderPasswordCounts(
+            listOf(
+                password("1", folderA, hidden = true),
+                password("2", folderA, trashed = true)
+            )
+        )
+        assertNull(counts[folderA])
+    }
+}


### PR DESCRIPTION
## Summary

Implements #79: each folder row in the folder list now shows a trailing number indicating how many passwords it directly contains. You approved this part of the request ("I like the suggestion of showing the number of passwords on a folder"); the URIs-per-item part you were unsure about is intentionally **not** included.

## Behavior / design choices

- **Direct children only.** A folder's number is the count of passwords whose `folder == folder.id` — i.e. exactly the passwords shown when you open that folder. Subfolders are not recursively summed; each subfolder shows its own count. Happy to switch to recursive totals if you'd prefer.
- **Hidden and trashed passwords are excluded**, so the number matches the list you see inside the folder.
- **Counts come from the full password list, not the search-filtered one**, so the numbers stay correct while a search query is active.
- **Always shown, including `0`** for empty folders (simplest, most predictable). Hiding the `0` is a one-line change if you'd rather.
- Counting is done once per list as a `Map<folderId, Int>` (`groupingBy { }.eachCount()`), so it's a single pass regardless of how many folder rows are visible.

## Changes

- `ItemList.kt`: new pure function `folderPasswordCounts(passwords)`; `MixedLazyColumn` and `FolderRow` take an optional count and render it as `trailingContent` (label style, `onSurfaceVariant`).
- `NCPNavHost.kt`: at the root and nested folder screens, compute the count map (remembered on the decrypted list) and pass it in.

## Testing

- Added JVM unit tests (`FolderPasswordCountTest`) covering per-folder counts, empty folders/lists, and the hidden/trashed exclusion. `./gradlew testDebugUnitTest` is green.
- Manually verified on an Android 15 emulator against a test server: the root folder list shows correct counts (e.g. `Private 9`, `Work 13`), subfolders show their own counts, and opening `Private` lists exactly 9 direct passwords — matching the number.

## Note

This contribution was made using AI (Claude). All generated code was proofread and validated by the committer.
