### PR TITLE
Don't wipe local data on a transient 401 during session/request (#137)

### DIFF
--- a/app/src/main/java/com/hegocre/nextcloudpasswords/api/ApiController.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/api/ApiController.kt
@@ -153,6 +153,11 @@ class ApiController private constructor(context: Context) {
                         "API Controller",
                         "Bad response on session request, user ${server.username}"
                     )
+
+                    Error.API_AUTH_ERROR -> Log.e(
+                        "API Controller",
+                        "Auth error on session request, user ${server.username}"
+                    )
                 }
             }
             return@withContext false

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/api/SessionApi.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/api/SessionApi.kt
@@ -14,6 +14,29 @@ import java.net.SocketTimeoutException
 import javax.net.ssl.SSLHandshakeException
 
 /**
+ * Outcome of an initial `session/request` call, classified by HTTP status.
+ *
+ * A `401` is treated as [RECOVERABLE_AUTH_ERROR] rather than a permanent
+ * deauthorization. The server returns `401` for any failed Nextcloud
+ * authentication — an expired or server-side-invalidated app token, but equally
+ * a `401` injected by something in front of Nextcloud (captive portal, reverse
+ * proxy, WAF) on a flaky connection. The body is empty in every case, so a
+ * transient `401` cannot be told apart from a genuine revocation, and a password
+ * manager must not destroy the locally cached (offline) vault over an ambiguous,
+ * possibly transient failure. Core brute-force throttling surfaces as `429`
+ * (handled as [BAD_RESPONSE]); only the Passwords app's explicit login-attempt
+ * lockout returns `403`, which is treated as [DEAUTHORIZED].
+ */
+enum class SessionRequestOutcome { SUCCESS, RECOVERABLE_AUTH_ERROR, DEAUTHORIZED, BAD_RESPONSE }
+
+fun classifySessionRequest(code: Int): SessionRequestOutcome = when (code) {
+    200 -> SessionRequestOutcome.SUCCESS
+    401 -> SessionRequestOutcome.RECOVERABLE_AUTH_ERROR
+    403 -> SessionRequestOutcome.DEAUTHORIZED
+    else -> SessionRequestOutcome.BAD_RESPONSE
+}
+
+/**
  * Class with methods used to interact with the
  * [Session API](https://git.mdns.eu/nextcloud/passwords/-/wikis/Developers/Api/Session-Api).
  * This is a Singleton class and will have only one instance.
@@ -57,12 +80,14 @@ class SessionApi private constructor(private var server: Server) {
                 apiResponse.close()
             }
 
-            if (code == 403 || code == 401)
-                throw ClientDeauthorizedException()
-
-            if (code == 200) {
-                Result.Success(PWDv1Challenge.fromJson(body))
-            } else Result.Error(Error.API_BAD_RESPONSE)
+            when (classifySessionRequest(code)) {
+                SessionRequestOutcome.SUCCESS -> Result.Success(PWDv1Challenge.fromJson(body))
+                // Keep the user logged in on a transient auth failure: the caller
+                // falls back to the cached keychain instead of wiping local data
+                SessionRequestOutcome.RECOVERABLE_AUTH_ERROR -> Result.Error(Error.API_AUTH_ERROR)
+                SessionRequestOutcome.DEAUTHORIZED -> throw ClientDeauthorizedException()
+                SessionRequestOutcome.BAD_RESPONSE -> Result.Error(Error.API_BAD_RESPONSE)
+            }
 
         } catch (e: SocketTimeoutException) {
             if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/Error.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/Error.kt
@@ -5,6 +5,7 @@ object Error {
     const val API_NO_CSE = 10001
     const val API_BAD_RESPONSE = 10002
     const val API_NO_SESSION = 10003
+    const val API_AUTH_ERROR = 10004
 
     const val SSL_HANDSHAKE_EXCEPTION = 20000
 

--- a/app/src/test/java/com/hegocre/nextcloudpasswords/SessionRequestClassificationTest.kt
+++ b/app/src/test/java/com/hegocre/nextcloudpasswords/SessionRequestClassificationTest.kt
@@ -1,0 +1,37 @@
+package com.hegocre.nextcloudpasswords
+
+import com.hegocre.nextcloudpasswords.api.SessionRequestOutcome
+import com.hegocre.nextcloudpasswords.api.classifySessionRequest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the classification of an initial `session/request` response.
+ *
+ * A `401` must be recoverable (not a permanent deauthorization) so an ambiguous
+ * or transient auth failure does not wipe the locally cached vault; only a `403`
+ * deauthorizes the client.
+ */
+class SessionRequestClassificationTest {
+    @Test
+    fun okIsSuccess() {
+        assertEquals(SessionRequestOutcome.SUCCESS, classifySessionRequest(200))
+    }
+
+    @Test
+    fun unauthorizedIsRecoverable() {
+        assertEquals(SessionRequestOutcome.RECOVERABLE_AUTH_ERROR, classifySessionRequest(401))
+    }
+
+    @Test
+    fun forbiddenIsDeauthorized() {
+        assertEquals(SessionRequestOutcome.DEAUTHORIZED, classifySessionRequest(403))
+    }
+
+    @Test
+    fun otherCodesAreBadResponse() {
+        assertEquals(SessionRequestOutcome.BAD_RESPONSE, classifySessionRequest(500))
+        assertEquals(SessionRequestOutcome.BAD_RESPONSE, classifySessionRequest(404))
+        assertEquals(SessionRequestOutcome.BAD_RESPONSE, classifySessionRequest(0))
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #137 (app logs itself out after a while and disables autofill).

## Root cause

`SessionApi.requestSession()` threw `ClientDeauthorizedException` on **both** 401 and 403:

```kotlin
if (code == 403 || code == 401)
    throw ClientDeauthorizedException()
```

Unlike a `Result.Error` — which `ApiController.openSession()` already handles gracefully by falling back to the cached keychain and keeping the user logged in — this exception propagates up to `PasswordsViewModel` (`_clientDeauthorized`), which triggers a full logout: the password and folder databases, the stored credentials and the cached keychain are all cleared and the app restarts to the login screen.

A **401 is not necessarily a permanent deauthorization**, and it is ambiguous. Verified against a live Nextcloud + Passwords server, `GET /session/request` returns:

| Situation | HTTP | Body |
|---|---|---|
| Valid auth | 200 | `{}` / challenge |
| Wrong / expired / revoked app token | 401 | `{"message":""}` |
| No credentials | 401 | `{"message":"Current user is not logged in"}` |
| Core brute-force limit reached | 429 | 429 page |
| Passwords-app login-attempt lockout | 403 | `{"message":"Login not allowed"}` |

A **revoked** app token returns exactly the same `401 {"message":""}` as a wrong password, so a 401 cannot be told apart from a transient failure by status code or body. Meanwhile Nextcloud's own brute-force protection surfaces as **429** (already handled here as a non-destructive `API_BAD_RESPONSE`), not 401. The destructive 401 therefore comes from a token invalidated server-side, or from a 401/403 injected by a captive portal / reverse proxy / WAF in front of Nextcloud on a flaky connection — which matches the #137 reports (recurs "after some time", on spotty mobile data, while the server had not revoked the session).

## Change

`requestSession()` now classifies the response and only an explicit **403** (the Passwords app's deliberate login-attempt lockout) deauthorizes; a **401** is a *recoverable* auth error that returns `Result.Error(API_AUTH_ERROR)`, so the existing cached-keychain fallback keeps the user logged in and the local vault intact. The classification is a pure function:

```kotlin
enum class SessionRequestOutcome { SUCCESS, RECOVERABLE_AUTH_ERROR, DEAUTHORIZED, BAD_RESPONSE }
fun classifySessionRequest(code: Int) = when (code) {
    200 -> SUCCESS; 401 -> RECOVERABLE_AUTH_ERROR; 403 -> DEAUTHORIZED; else -> BAD_RESPONSE
}
```

Files: `SessionApi.kt` (classifier + use it), `Error.kt` (`API_AUTH_ERROR`), `ApiController.kt` (log the new code alongside the existing ones).

## Testing

- **Unit tests** (`SessionRequestClassificationTest`): 200→SUCCESS, 401→RECOVERABLE_AUTH_ERROR, 403→DEAUTHORIZED, other→BAD_RESPONSE. Green.
- **Live behaviour**: created / verified / revoked an app token against a real server and confirmed the status/body table above (revoked token → `401 {"message":""}`).
- **Emulator (Android 15)**: happy path unaffected — login, session open and sync work.

## Trade-off worth your call

A genuinely revoked app password (also a 401) no longer auto-logs-out; the user keeps the cached, E2E-encrypted vault with a session error and logs out manually. For a password manager I think not destroying the local vault on an ambiguous 401 is the safer default, but an alternative is to retry a few times and only then deauthorize. Happy to adjust.

## Note

This contribution was made with AI assistance (Claude). All generated code was proofread and validated by the committer against a live server and the source.
