### PR TITLE
Mark copied secret custom fields as sensitive

### DIFF
--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/CustomField.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/CustomField.kt
@@ -15,6 +15,14 @@ data class CustomField(
     val type: String,
     val value: String
 ) {
+    /**
+     * Whether this field holds a secret value. Secret fields are masked in the UI and
+     * should be marked as sensitive when copied, so the system keeps them out of the
+     * clipboard preview and history (Android 13+), just like the account password.
+     */
+    val isSensitive: Boolean
+        get() = type == TYPE_SECRET
+
     companion object {
         const val TYPE_TEXT = "text"
         const val TYPE_SECRET = "secret"

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -347,7 +347,7 @@ fun PasswordItemContent(
                                 },
                                 trailingIcon = {
                                     IconButton(onClick = {
-                                        context.copyToClipboard(customField.value)
+                                        context.copyToClipboard(customField.value, isSensitive = customField.isSensitive)
                                         Toast.makeText(
                                             context,
                                             String.format(copiedText, customField.label),
@@ -378,7 +378,7 @@ fun PasswordItemContent(
                                 },
                                 trailingIcon = {
                                     IconButton(onClick = {
-                                        context.copyToClipboard(customField.value)
+                                        context.copyToClipboard(customField.value, isSensitive = customField.isSensitive)
                                         Toast.makeText(
                                             context,
                                             String.format(copiedText, customField.label),
@@ -409,7 +409,7 @@ fun PasswordItemContent(
                                 },
                                 trailingIcon = {
                                     IconButton(onClick = {
-                                        context.copyToClipboard(customField.value)
+                                        context.copyToClipboard(customField.value, isSensitive = customField.isSensitive)
                                         Toast.makeText(
                                             context,
                                             String.format(copiedText, customField.label),

--- a/app/src/test/java/com/hegocre/nextcloudpasswords/data/password/CustomFieldTest.kt
+++ b/app/src/test/java/com/hegocre/nextcloudpasswords/data/password/CustomFieldTest.kt
@@ -1,0 +1,32 @@
+package com.hegocre.nextcloudpasswords.data.password
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit test for [CustomField.isSensitive], which decides whether a custom field value
+ * must be flagged as sensitive when copied to the clipboard.
+ */
+class CustomFieldTest {
+    private fun field(type: String) = CustomField(label = "label", type = type, value = "value")
+
+    @Test
+    fun secretFieldIsSensitive() {
+        assertTrue(field(CustomField.TYPE_SECRET).isSensitive)
+    }
+
+    @Test
+    fun nonSecretFieldsAreNotSensitive() {
+        assertFalse(field(CustomField.TYPE_TEXT).isSensitive)
+        assertFalse(field(CustomField.TYPE_EMAIL).isSensitive)
+        assertFalse(field(CustomField.TYPE_URL).isSensitive)
+        assertFalse(field(CustomField.TYPE_FILE).isSensitive)
+        assertFalse(field(CustomField.TYPE_DATA).isSensitive)
+    }
+
+    @Test
+    fun unknownTypeIsNotSensitive() {
+        assertFalse(field("something-else").isSensitive)
+    }
+}


### PR DESCRIPTION
## What

Secret custom fields are masked in the details view (●●●, shield icon, reveal toggle) exactly like the account password. But copying such a field put its value on the clipboard **without** the sensitive flag, whereas the password field is already copied with `isSensitive = true`.

On Android 13+ this means a secret custom field's value could:
- appear in the clipboard preview/toast shown right after copying, and
- be retained in the system clipboard history.

## Change

- Add `CustomField.isSensitive` (true only for `TYPE_SECRET`).
- Use it at the custom-field copy actions in `PasswordItem`, so secret fields are copied with `ClipDescription.EXTRA_IS_SENSITIVE`, consistent with the password field. Non-secret fields (text / email / url) keep their previous behaviour (not flagged).

## Tests

- Added `CustomFieldTest` (JVM unit test) covering `isSensitive` for every field type.
- `./gradlew testDebugUnitTest --tests "*CustomFieldTest"` → 3 passed, 0 failed.
- `./gradlew assembleDebug` succeeds.

On-device visual check of the clipboard preview still recommended.

---

*Disclosure: this change was prepared with AI assistance (Claude Code - Opus 4.8 xhigh) and reviewed by me before submission.*
