### PR TITLE
Implement OTP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,9 @@ dependencies {
 
     implementation 'com.materialkolor:material-kolor:5.0.1'
 
+    implementation 'dev.turingcomplete:kotlin-onetimepassword:3.0.0'
+    implementation 'commons-codec:commons-codec:1.22.1'
+
     testImplementation 'junit:junit:4.13.2'
 
     androidTestImplementation 'androidx.arch.core:core-testing:2.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,6 +118,7 @@ dependencies {
 
     implementation 'dev.turingcomplete:kotlin-onetimepassword:3.0.0'
     implementation 'commons-codec:commons-codec:1.22.1'
+    implementation 'io.github.g00fy2.quickie:quickie-bundled:1.12.0'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/app/src/androidTest/java/com/hegocre/nextcloudpasswords/utils/OTPTest.kt
+++ b/app/src/androidTest/java/com/hegocre/nextcloudpasswords/utils/OTPTest.kt
@@ -1,0 +1,113 @@
+package com.hegocre.nextcloudpasswords.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OTPTest {
+
+    @Test
+    fun parseValidTotpUrlDefaultValues() {
+        val url = "otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+        val otp = OTP.fromUrl(url)
+
+        assertEquals("JBSWY3DPEHPK3PXP", otp.secret)
+        assertEquals("totp", otp.type)
+        assertEquals("sha1", otp.algorithm)
+        assertEquals(6, otp.digits)
+        assertEquals(30, otp.period)
+        assertEquals(0L, otp.counter)
+        assertEquals("Example", otp.issuer)
+        assertEquals("alice@google.com", otp.accountName)
+    }
+
+    @Test
+    fun parseValidTotpUrlCustomParameters() {
+        val url = "otpauth://totp/My%20Service:user123?secret=GEZDGNBVGY3TQOJQ&issuer=My%20Service&algorithm=SHA256&digits=8&period=60"
+        val otp = OTP.fromUrl(url)
+
+        assertEquals("GEZDGNBVGY3TQOJQ", otp.secret)
+        assertEquals("totp", otp.type)
+        assertEquals("sha256", otp.algorithm)
+        assertEquals(8, otp.digits)
+        assertEquals(60, otp.period)
+        assertEquals("My Service", otp.issuer)
+        assertEquals("user123", otp.accountName)
+    }
+
+    @Test
+    fun parseValidHotpUrl() {
+        val url = "otpauth://hotp/Bank:alice@bank.com?secret=JBSWY3DPEHPK3PXP&counter=5"
+        val otp = OTP.fromUrl(url)
+
+        assertEquals("JBSWY3DPEHPK3PXP", otp.secret)
+        assertEquals("hotp", otp.type)
+        assertEquals(5L, otp.counter)
+        assertEquals("Bank", otp.issuer)
+        assertEquals("alice@bank.com", otp.accountName)
+    }
+
+    @Test(expected = OtpParseException.InvalidUrl::class)
+    fun invalidSchemeThrowsException() {
+        OTP.fromUrl("http://totp/example?secret=JBSWY3DPEHPK3PXP")
+    }
+
+    @Test(expected = OtpParseException.InvalidType::class)
+    fun invalidTypeThrowsException() {
+        OTP.fromUrl("otpauth://unknown/example?secret=JBSWY3DPEHPK3PXP")
+    }
+
+    @Test(expected = OtpParseException.MissingSecret::class)
+    fun missingSecretThrowsException() {
+        OTP.fromUrl("otpauth://totp/example")
+    }
+
+    @Test(expected = OtpParseException.InvalidSecret::class)
+    fun invalidSecretAlphabetThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=INVALID_SECRET_123!")
+    }
+
+    @Test(expected = OtpParseException.InvalidAlgorithm::class)
+    fun invalidAlgorithmThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&algorithm=MD5")
+    }
+
+    @Test(expected = OtpParseException.MissingCounter::class)
+    fun hotpMissingCounterThrowsException() {
+        OTP.fromUrl("otpauth://hotp/example?secret=JBSWY3DPEHPK3PXP")
+    }
+
+    @Test(expected = OtpParseException.MissingCounter::class)
+    fun hotpNegativeCounterThrowsException() {
+        OTP.fromUrl("otpauth://hotp/example?secret=JBSWY3DPEHPK3PXP&counter=-1")
+    }
+
+    @Test(expected = OtpParseException.InvalidDigits::class)
+    fun invalidDigitsTooSmallThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&digits=5")
+    }
+
+    @Test(expected = OtpParseException.InvalidDigits::class)
+    fun invalidDigitsTooLargeThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&digits=10")
+    }
+
+    @Test(expected = OtpParseException.InvalidDigits::class)
+    fun invalidDigitsNonNumericThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&digits=abc")
+    }
+
+    @Test(expected = OtpParseException.InvalidPeriod::class)
+    fun invalidPeriodZeroThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&period=0")
+    }
+
+    @Test(expected = OtpParseException.InvalidPeriod::class)
+    fun invalidPeriodNegativeThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&period=-30")
+    }
+
+    @Test(expected = OtpParseException.InvalidPeriod::class)
+    fun invalidPeriodNonNumericThrowsException() {
+        OTP.fromUrl("otpauth://totp/example?secret=JBSWY3DPEHPK3PXP&period=abc")
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,12 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission"
         tools:targetApi="s" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/CustomField.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/CustomField.kt
@@ -30,5 +30,6 @@ data class CustomField(
         const val TYPE_URL = "url"
         const val TYPE_FILE = "file"
         const val TYPE_DATA = "data"
+
     }
 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/CustomField.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/CustomField.kt
@@ -30,6 +30,5 @@ data class CustomField(
         const val TYPE_URL = "url"
         const val TYPE_FILE = "file"
         const val TYPE_DATA = "data"
-
     }
 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/NewPassword.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/NewPassword.kt
@@ -1,5 +1,7 @@
 package com.hegocre.nextcloudpasswords.data.password
 
+import com.hegocre.nextcloudpasswords.api.encryption.CSEv1Keychain
+import com.hegocre.nextcloudpasswords.utils.encryptValue
 import kotlinx.serialization.Serializable
 
 /**
@@ -35,4 +37,17 @@ data class NewPassword(
     val edited: Int,
     val hidden: Boolean,
     val favorite: Boolean,
-)
+) {
+    fun encrypt(cseKey: String, csEv1Keychain: CSEv1Keychain): NewPassword {
+        return this.copy(
+            password = password.encryptValue(cseKey, csEv1Keychain),
+            label = label.encryptValue(cseKey, csEv1Keychain),
+            username = username.encryptValue(cseKey, csEv1Keychain),
+            url = url.encryptValue(cseKey, csEv1Keychain),
+            notes = notes.encryptValue(cseKey, csEv1Keychain),
+            customFields = customFields.encryptValue(cseKey, csEv1Keychain),
+            cseType = "CSEv1r1",
+            cseKey = cseKey,
+        )
+    }
+}

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase
 import androidx.core.net.toUri
+import com.hegocre.nextcloudpasswords.utils.OTP
+import kotlinx.serialization.json.Json
 
 /**
  * Data class representing a
@@ -129,5 +131,17 @@ data class Password(
         } catch (_: Exception) {
             return false
         }
+    }
+
+    fun getOTP(): Pair<String?, Long?> {
+        if (customFields.isNotBlank()) {
+            val otpField = Json.decodeFromString<List<CustomField>>(customFields)
+                .find { it.label == OTP.CUSTOM_FIELD_LABEL }
+            if (otpField != null) {
+                val otp = Json.decodeFromString<OTP>(otpField.value)
+                return otp.getCurrent()
+            }
+        }
+        return Pair(null, null)
     }
 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
@@ -135,8 +135,8 @@ data class Password(
 
     fun getOTP(): Pair<String?, Long?> {
         if (customFields.isNotBlank()) {
-            val otpField = Json.decodeFromString<List<CustomField>>(customFields)
-                .find { it.label == OTP.CUSTOM_FIELD_LABEL }
+            val otpField = try { Json.decodeFromString<List<CustomField>>(customFields)
+                .find { it.label == OTP.CUSTOM_FIELD_LABEL } } catch (_: Exception) { return Pair(null, null) }
             if (otpField != null) {
                 val otp = Json.decodeFromString<OTP>(otpField.value)
                 return otp.getCurrent()

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
@@ -138,7 +138,11 @@ data class Password(
             val otpField = try { Json.decodeFromString<List<CustomField>>(customFields)
                 .find { it.label == OTP.CUSTOM_FIELD_LABEL } } catch (_: Exception) { return Pair(null, null) }
             if (otpField != null) {
-                val otp = Json.decodeFromString<OTP>(otpField.value)
+                val otp = try {
+                    Json.decodeFromString<OTP>(otpField.value)
+                } catch (_: Exception) {
+                    return Pair(null, null)
+                }
                 return otp.getCurrent()
             }
         }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/Password.kt
@@ -138,12 +138,12 @@ data class Password(
             val otpField = try { Json.decodeFromString<List<CustomField>>(customFields)
                 .find { it.label == OTP.CUSTOM_FIELD_LABEL } } catch (_: Exception) { return Pair(null, null) }
             if (otpField != null) {
-                val otp = try {
-                    Json.decodeFromString<OTP>(otpField.value)
+                try {
+                    val otp = Json.decodeFromString<OTP>(otpField.value)
+                    return otp.getCurrent()
                 } catch (_: Exception) {
                     return Pair(null, null)
                 }
-                return otp.getCurrent()
             }
         }
         return Pair(null, null)

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/UpdatedPassword.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/data/password/UpdatedPassword.kt
@@ -1,5 +1,7 @@
 package com.hegocre.nextcloudpasswords.data.password
 
+import com.hegocre.nextcloudpasswords.api.encryption.CSEv1Keychain
+import com.hegocre.nextcloudpasswords.utils.encryptValue
 import kotlinx.serialization.Serializable
 
 /**
@@ -39,4 +41,17 @@ data class UpdatedPassword(
     val edited: Int,
     val hidden: Boolean,
     val favorite: Boolean,
-)
+) {
+    fun encrypt(cseKey: String, csEv1Keychain: CSEv1Keychain): UpdatedPassword {
+        return this.copy(
+            password = password.encryptValue(cseKey, csEv1Keychain),
+            label = label.encryptValue(cseKey, csEv1Keychain),
+            username = username.encryptValue(cseKey, csEv1Keychain),
+            url = url.encryptValue(cseKey, csEv1Keychain),
+            notes = notes.encryptValue(cseKey, csEv1Keychain),
+            customFields = customFields.encryptValue(cseKey, csEv1Keychain),
+            cseType = "CSEv1r1",
+            cseKey = cseKey,
+        )
+    }
+}

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/services/autofill/NCPAutofillService.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/services/autofill/NCPAutofillService.kt
@@ -221,7 +221,7 @@ class NCPAutofillService : AutofillService() {
             for ((idx, password) in passwords.withIndex()) {
                 val copyOtp = PreferencesManager.getInstance(this).getCopyOTPOnAutofill()
                 // Only copy when it is TOTP
-                val hasTOTP = password.getOTP().let { it.first != null && it.second != null }
+                val hasTOTP = copyOtp && password.getOTP().let { it.first != null && it.second != null }
 
                 builder.addDataset(
                     AutofillHelper.buildDataset(
@@ -235,7 +235,7 @@ class NCPAutofillService : AutofillService() {
                             password = password.password
                         ),
                         null,
-                        needsAuth || (hasTOTP && copyOtp),
+                        needsAuth || hasTOTP,
                         idx
                     )
                 )

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/services/autofill/NCPAutofillService.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/services/autofill/NCPAutofillService.kt
@@ -219,6 +219,10 @@ class NCPAutofillService : AutofillService() {
         if (!needsAppForMasterPassword) {
             // Add one Dataset for each password
             for ((idx, password) in passwords.withIndex()) {
+                val copyOtp = PreferencesManager.getInstance(this).getCopyOTPOnAutofill()
+                // Only copy when it is TOTP
+                val hasTOTP = password.getOTP().let { it.first != null && it.second != null }
+
                 builder.addDataset(
                     AutofillHelper.buildDataset(
                         applicationContext,
@@ -231,7 +235,7 @@ class NCPAutofillService : AutofillService() {
                             password = password.password
                         ),
                         null,
-                        needsAuth,
+                        needsAuth || (hasTOTP && copyOtp),
                         idx
                     )
                 )

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/CommonComposables.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/CommonComposables.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -21,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -91,7 +93,9 @@ fun OutlinedClickableTextField(
     value: String,
     label: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    textStyle: TextStyle = LocalTextStyle.current
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -107,7 +111,9 @@ fun OutlinedClickableTextField(
                 maxLines = 1,
                 modifier = modifier,
                 readOnly = true,
-                colors = OutlinedTextFieldDefaults.colors(cursorColor = Color.Transparent)
+                colors = OutlinedTextFieldDefaults.colors(cursorColor = Color.Transparent),
+                visualTransformation = visualTransformation,
+                textStyle = textStyle
             )
         }
         Box(

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -85,6 +85,7 @@ import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
 import com.hegocre.nextcloudpasswords.utils.OTP
 import com.hegocre.nextcloudpasswords.utils.OtpParseException
 import com.hegocre.nextcloudpasswords.utils.PreferencesManager
+import com.hegocre.nextcloudpasswords.utils.isValidSecret
 import io.github.g00fy2.quickie.QRResult
 import io.github.g00fy2.quickie.ScanQRCode
 import kotlinx.coroutines.Dispatchers
@@ -481,12 +482,12 @@ fun EditOtpDialog(
                         maxLines = 1,
                         textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily(Font(R.font.dejavu_sans_mono))),
                         label = { Text(text = stringResource(R.string.otp_secret)) },
-                        isError = showInputErrors && (secret.isBlank() || !Base32().isInAlphabet(secret)),
+                        isError = showInputErrors && !secret.isValidSecret(),
                         supportingText = if (showInputErrors && secret.isBlank()) {
                             {
                                 Text(text = stringResource(id = R.string.error_field_cannot_be_empty))
                             }
-                        } else if (showInputErrors && !Base32().isInAlphabet(secret)) {
+                        } else if (showInputErrors && !secret.isValidSecret()) {
                             {
                                 Text(text = stringResource(R.string.error_invalid_secret))
                             }
@@ -653,8 +654,7 @@ fun EditOtpDialog(
 
                     TextButton(
                         onClick = {
-                            if (secret.isBlank() ||
-                                !Base32().isInAlphabet(secret) ||
+                            if (!secret.isValidSecret() ||
                                 (digits.toIntOrNull() ?: 6) !in 6..9 ||
                                 (type == OTP.Companion.Type.TOTP && (period.toIntOrNull() ?: 30) < 1) ||
                                 (type == OTP.Companion.Type.HOTP && (counter.toLongOrNull() ?: 30L) < 0)

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -1,5 +1,7 @@
 package com.hegocre.nextcloudpasswords.ui.components
 
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -18,6 +20,9 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
@@ -76,6 +81,8 @@ import com.hegocre.nextcloudpasswords.ui.theme.ContentAlpha
 import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
 import com.hegocre.nextcloudpasswords.utils.OTP
 import com.hegocre.nextcloudpasswords.utils.PreferencesManager
+import io.github.g00fy2.quickie.QRResult
+import io.github.g00fy2.quickie.ScanQRCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
@@ -404,11 +411,48 @@ fun EditOtpDialog(
             tonalElevation = 6.dp,
         ) {
             Column(modifier = Modifier.padding(all = 24.dp)) {
-                Text(
-                    text = "OTP",
-                    style = MaterialTheme.typography.headlineSmall,
-                    modifier = Modifier.padding(bottom = 16.dp)
-                )
+                Row (modifier = Modifier.padding(bottom = 8.dp), verticalAlignment = CenterVertically) {
+                    val scanQrCodeLauncher = rememberLauncherForActivityResult(ScanQRCode()) { result ->
+                        when (result) {
+                            is QRResult.QRSuccess -> {
+                                val otpUri = result.content.rawValue
+                                if (otpUri != null) {
+                                    Log.d("QR", otpUri)
+                                    try {
+                                        val otp = OTP.fromUrl(otpUri)
+                                        setSecret(otp.secret)
+                                        setType(otp.type)
+                                        setAlgorithm(otp.algorithm)
+                                        setDigits(otp.digits.toString())
+                                        setCounter(otp.counter.toString())
+                                        setPeriod(otp.period.toString())
+                                    } catch (e: IllegalArgumentException) {
+                                        Log.d("QR", "${e.message}")
+                                    }
+                                }
+                            }
+                            else -> {
+                                //Error
+                            }
+                        }
+                    }
+
+                    Text(
+                        text = "OTP",
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+
+                    IconButton(
+                        onClick = {
+                            scanQrCodeLauncher.launch(null)
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.QrCode,
+                            contentDescription = "QR Code"
+                        )
+                    }
+                }
 
                 Column(
                     modifier = Modifier
@@ -1104,5 +1148,13 @@ fun ListPreferenceDialogPreview() {
 fun GeneratePasswordDialogPreview() {
     NextcloudPasswordsTheme {
         PasswordGenerationDialog(onGenerate = { _, _, _ -> })
+    }
+}
+
+@Preview
+@Composable
+fun EditOtpDialogPreview() {
+    NextcloudPasswordsTheme {
+        EditOtpDialog(onSaveClick = {}, onDeleteClick = {})
     }
 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -398,6 +398,9 @@ fun EditOtpDialog(
     val (digits, setDigits) = remember { mutableStateOf(currentOtp.digits.toString()) }
     val (counter, setCounter) = remember { mutableStateOf(currentOtp.counter.toString()) }
     val (period, setPeriod) = remember { mutableStateOf(currentOtp.period.toString()) }
+    val (issuer, setIssuer) = remember { mutableStateOf(currentOtp.issuer) }
+    val (accountName, setAccountName) = remember { mutableStateOf(currentOtp.accountName) }
+
 
     var typeMenuExpanded by remember { mutableStateOf(false) }
     var algorithmMenuExpanded by remember { mutableStateOf(false) }
@@ -432,6 +435,8 @@ fun EditOtpDialog(
                                         setDigits(otp.digits.toString())
                                         setCounter(otp.counter.toString())
                                         setPeriod(otp.period.toString())
+                                        setIssuer(otp.issuer)
+                                        setAccountName(otp.accountName)
                                     } catch (e: OtpParseException) {
                                         Toast.makeText(context, resources.getString(e.stringResId), Toast.LENGTH_LONG).show()
                                     }
@@ -662,7 +667,9 @@ fun EditOtpDialog(
                                         algorithm,
                                         digits.toIntOrNull() ?: 6,
                                         counter.toLongOrNull() ?: 0L,
-                                        period.toIntOrNull() ?: 30
+                                        period.toIntOrNull() ?: 30,
+                                        issuer,
+                                        accountName
                                     )
                                 )
                             }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -1,6 +1,6 @@
 package com.hegocre.nextcloudpasswords.ui.components
 
-import android.util.Log
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -65,6 +65,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -80,12 +81,14 @@ import com.hegocre.nextcloudpasswords.data.password.RequestedPassword
 import com.hegocre.nextcloudpasswords.ui.theme.ContentAlpha
 import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
 import com.hegocre.nextcloudpasswords.utils.OTP
+import com.hegocre.nextcloudpasswords.utils.OtpParseException
 import com.hegocre.nextcloudpasswords.utils.PreferencesManager
 import io.github.g00fy2.quickie.QRResult
 import io.github.g00fy2.quickie.ScanQRCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import org.apache.commons.codec.binary.Base32
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -151,7 +154,7 @@ fun MasterPasswordDialog(
                             modifier = Modifier.align(CenterVertically)
                         )
                         Text(
-                            text = "Save password",
+                            text = stringResource(R.string.save_password),
                             modifier = Modifier
                                 .align(CenterVertically)
                                 .pointerInput(Unit) {
@@ -376,15 +379,15 @@ fun EditOtpDialog(
     onDismissRequest: (() -> Unit)? = null,
     currentOtp: OTP = OTP(secret = "")
 ) {
-    val types = listOf(
-        OTP.Companion.Type.TOTP,
-        OTP.Companion.Type.HOTP
+    val types = mapOf(
+        OTP.Companion.Type.TOTP to stringResource(R.string.otp_type_totp),
+        OTP.Companion.Type.HOTP to stringResource(R.string.otp_type_hotp)
     )
 
-    val algorithms = listOf(
-        OTP.Companion.Algorithm.SHA1,
-        OTP.Companion.Algorithm.SHA256,
-        OTP.Companion.Algorithm.SHA512
+    val algorithms = mapOf(
+        OTP.Companion.Algorithm.SHA1 to "${OTP.Companion.Algorithm.SHA1.uppercase()} (${stringResource(R.string.value_default)})",
+        OTP.Companion.Algorithm.SHA256 to OTP.Companion.Algorithm.SHA256.uppercase(),
+        OTP.Companion.Algorithm.SHA512 to OTP.Companion.Algorithm.SHA512.uppercase()
     )
 
     val (secret, setSecret) = remember { mutableStateOf(currentOtp.secret) }
@@ -397,7 +400,7 @@ fun EditOtpDialog(
     var typeMenuExpanded by remember { mutableStateOf(false) }
     var algorithmMenuExpanded by remember { mutableStateOf(false) }
 
-    var showEmptyError by rememberSaveable {
+    var showInputErrors by rememberSaveable {
         mutableStateOf(false)
     }
 
@@ -412,12 +415,13 @@ fun EditOtpDialog(
         ) {
             Column(modifier = Modifier.padding(all = 24.dp)) {
                 Row (modifier = Modifier.padding(bottom = 8.dp), verticalAlignment = CenterVertically) {
+                    val context = LocalContext.current
+                    val resources = LocalResources.current
                     val scanQrCodeLauncher = rememberLauncherForActivityResult(ScanQRCode()) { result ->
                         when (result) {
                             is QRResult.QRSuccess -> {
                                 val otpUri = result.content.rawValue
                                 if (otpUri != null) {
-                                    Log.d("QR", otpUri)
                                     try {
                                         val otp = OTP.fromUrl(otpUri)
                                         setSecret(otp.secret)
@@ -426,19 +430,20 @@ fun EditOtpDialog(
                                         setDigits(otp.digits.toString())
                                         setCounter(otp.counter.toString())
                                         setPeriod(otp.period.toString())
-                                    } catch (e: IllegalArgumentException) {
-                                        Log.d("QR", "${e.message}")
+                                    } catch (e: OtpParseException) {
+                                        Toast.makeText(context, resources.getString(e.stringResId), Toast.LENGTH_LONG).show()
                                     }
                                 }
                             }
-                            else -> {
-                                //Error
+                            is QRResult.QRError -> {
+                                Toast.makeText(context, result.exception.localizedMessage, Toast.LENGTH_LONG).show()
                             }
+                            is QRResult.QRUserCanceled, is QRResult.QRMissingPermission -> {}
                         }
                     }
 
                     Text(
-                        text = "OTP",
+                        text = stringResource(R.string.otp_title),
                         style = MaterialTheme.typography.headlineSmall
                     )
 
@@ -449,7 +454,7 @@ fun EditOtpDialog(
                     ) {
                         Icon(
                             imageVector = Icons.Default.QrCode,
-                            contentDescription = "QR Code"
+                            contentDescription = stringResource(R.string.scan_qr_code)
                         )
                     }
                 }
@@ -466,11 +471,15 @@ fun EditOtpDialog(
                         onValueChange = setSecret,
                         singleLine = true,
                         maxLines = 1,
-                        label = { Text(text = "Secret") },
-                        isError = showEmptyError && secret.isBlank(),
-                        supportingText = if (showEmptyError && secret.isBlank()) {
+                        label = { Text(text = stringResource(R.string.otp_secret)) },
+                        isError = showInputErrors && (secret.isBlank() || !Base32().isInAlphabet(secret)),
+                        supportingText = if (showInputErrors && secret.isBlank()) {
                             {
                                 Text(text = stringResource(id = R.string.error_field_cannot_be_empty))
+                            }
+                        } else if (showInputErrors && !Base32().isInAlphabet(secret)) {
+                            {
+                                Text(text = stringResource(R.string.error_invalid_secret))
                             }
                         } else null
                     )
@@ -481,11 +490,11 @@ fun EditOtpDialog(
                         .padding(top = 16.dp, bottom = 8.dp)
                         .clickable(onClick = { showAdvancedOptions = !showAdvancedOptions })
                     ) {
-                        Text(text = "Show advanced options")
+                        Text(text = stringResource(R.string.show_advanced_options))
 
                         Icon(
                             imageVector = if (showAdvancedOptions) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                            contentDescription = "Toggle advanced"
+                            contentDescription = stringResource(R.string.toggle_advanced_options)
                         )
                     }
 
@@ -497,11 +506,11 @@ fun EditOtpDialog(
                         ) {
                             OutlinedTextField(
                                 modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                                value = type.uppercase(),
+                                value = types[type] ?: "",
                                 onValueChange = {},
                                 readOnly = true,
                                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
-                                label = { Text(text = "Type") },
+                                label = { Text(text = stringResource(R.string.otp_type)) },
                                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
                             )
 
@@ -511,9 +520,9 @@ fun EditOtpDialog(
                             ) {
                                 types.forEach { type ->
                                     DropdownMenuItem(
-                                        text = { Text(text = type.uppercase()) },
+                                        text = { Text(text = type.value) },
                                         onClick = {
-                                            setType(type)
+                                            setType(type.key)
                                             typeMenuExpanded = false
                                         },
                                         contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
@@ -529,11 +538,11 @@ fun EditOtpDialog(
                         ) {
                             OutlinedTextField(
                                 modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                                value = algorithm.uppercase(),
+                                value = algorithms[algorithm] ?: "",
                                 onValueChange = {},
                                 readOnly = true,
                                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
-                                label = { Text(text = "Algorithm") },
+                                label = { Text(text = stringResource(R.string.otp_algorithm)) },
                                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
                             )
 
@@ -543,9 +552,9 @@ fun EditOtpDialog(
                             ) {
                                 algorithms.forEach { algorithm ->
                                     DropdownMenuItem(
-                                        text = { Text(text = algorithm.uppercase()) },
+                                        text = { Text(text = algorithm.value) },
                                         onClick = {
-                                            setAlgorithm(algorithm)
+                                            setAlgorithm(algorithm.key)
                                             algorithmMenuExpanded = false
                                         },
                                         contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
@@ -560,19 +569,33 @@ fun EditOtpDialog(
                             onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setDigits(it) },
                             singleLine = true,
                             maxLines = 1,
-                            label = { Text(text = "Digits") },
-                            placeholder = { Text(text = "6") }
+                            label = { Text(text = stringResource(R.string.otp_digits)) },
+                            placeholder = { Text(text = "6") },
+                            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+                            isError = showInputErrors && (digits.toIntOrNull() ?: 6) !in 6..9,
+                            supportingText = if (showInputErrors && (digits.toIntOrNull() ?: 6) !in 6..9) {
+                                {
+                                    Text(text = stringResource(id = R.string.otp_invalid_digit_range_error))
+                                }
+                            } else null
                         )
 
                         if (type == OTP.Companion.Type.HOTP) {
                             OutlinedTextField(
                                 modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
                                 value = counter,
-                                onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setCounter(it) },
+                                onValueChange = { if ((it.toLongOrNull() != null && it.toLong() >= 0) || it.isEmpty()) setCounter(it) },
                                 singleLine = true,
                                 maxLines = 1,
-                                label = { Text(text = "Counter") },
-                                placeholder = { Text(text = "0") }
+                                label = { Text(text = stringResource(R.string.otp_counter)) },
+                                placeholder = { Text(text = "0") },
+                                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+                                isError = showInputErrors && (counter.toLongOrNull() ?: 30L) < 0,
+                                supportingText = if (showInputErrors && (counter.toLongOrNull() ?: 30L) < 0) {
+                                    {
+                                        Text(text = stringResource(id = R.string.otp_invalid_counter_error))
+                                    }
+                                } else null
                             )
                         }
 
@@ -580,29 +603,43 @@ fun EditOtpDialog(
                             OutlinedTextField(
                                 modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
                                 value = period,
-                                onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setPeriod(it) },
+                                onValueChange = { if ((it.toIntOrNull() != null && it.toInt() >= 0) || it.isEmpty()) setPeriod(it) },
                                 singleLine = true,
                                 maxLines = 1,
-                                label = { Text(text = "Period") },
-                                placeholder = { Text(text = "30") }
+                                label = { Text(text = stringResource(R.string.otp_period)) },
+                                placeholder = { Text(text = "30") },
+                                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+                                isError = showInputErrors && (period.toIntOrNull() ?: 30) < 1,
+                                supportingText = if (showInputErrors && (period.toIntOrNull() ?: 30) < 1) {
+                                    {
+                                        Text(text = stringResource(id = R.string.otp_invalid_period_error))
+                                    }
+                                } else null
                             )
                         }
                     }
                 }
 
 
-                Row (modifier = Modifier.align(Alignment.End).padding(top = 8.dp)) {
+                Row (modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(top = 8.dp)) {
                     TextButton(
                         onClick = onDeleteClick,
                         modifier = Modifier.padding(end = 8.dp)
                     ) {
-                        Text(text = "Delete")
+                        Text(text = stringResource(R.string.action_delete))
                     }
 
                     TextButton(
                         onClick = {
-                            if (secret.isBlank()) {
-                                showEmptyError = true
+                            if (secret.isBlank() ||
+                                !Base32().isInAlphabet(secret) ||
+                                (digits.toIntOrNull() ?: 6) !in 6..9 ||
+                                (type == OTP.Companion.Type.TOTP && (period.toIntOrNull() ?: 30) < 1) ||
+                                (type == OTP.Companion.Type.HOTP && (counter.toLongOrNull() ?: 30L) < 0)
+                            ) {
+                                showInputErrors = true
                             } else {
                                 onSaveClick(
                                     OTP(secret,

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -141,12 +141,12 @@ fun MasterPasswordDialog(
                         Checkbox(
                             checked = savePassword,
                             onCheckedChange = setSavePassword,
-                            modifier = Modifier.align(Alignment.CenterVertically)
+                            modifier = Modifier.align(CenterVertically)
                         )
                         Text(
                             text = "Save password",
                             modifier = Modifier
-                                .align(Alignment.CenterVertically)
+                                .align(CenterVertically)
                                 .pointerInput(Unit) {
                                     detectTapGestures {
                                         setSavePassword(!savePassword)
@@ -365,6 +365,7 @@ fun AddCustomFieldDialog(
 @Composable
 fun EditOtpDialog(
     onSaveClick: (OTP) -> Unit,
+    onDeleteClick: () -> Unit,
     onDismissRequest: (() -> Unit)? = null,
     currentOtp: OTP = OTP(secret = "")
 ) {
@@ -546,27 +547,33 @@ fun EditOtpDialog(
                 }
 
 
-                TextButton(
-                    onClick = {
-                        if (secret.isBlank()) {
-                            showEmptyError = true
-                        } else {
-                            onSaveClick(
-                                OTP(secret,
-                                    type,
-                                    algorithm,
-                                    digits.toIntOrNull() ?: 6,
-                                    counter.toIntOrNull() ?: 0,
-                                    period.toIntOrNull() ?: 30
+                Row (modifier = Modifier.align(Alignment.End).padding(top = 8.dp)) {
+                    TextButton(
+                        onClick = onDeleteClick,
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text(text = "Delete")
+                    }
+
+                    TextButton(
+                        onClick = {
+                            if (secret.isBlank()) {
+                                showEmptyError = true
+                            } else {
+                                onSaveClick(
+                                    OTP(secret,
+                                        type,
+                                        algorithm,
+                                        digits.toIntOrNull() ?: 6,
+                                        counter.toLongOrNull() ?: 0L,
+                                        period.toIntOrNull() ?: 30
+                                    )
                                 )
-                            )
-                        }
-                    },
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .padding(horizontal = 0.dp)
-                ) {
-                    Text(text = stringResource(android.R.string.ok))
+                            }
+                        },
+                    ) {
+                        Text(text = stringResource(android.R.string.ok))
+                    }
                 }
             }
         }
@@ -850,7 +857,7 @@ fun ListPreferenceDialog(
                 ) {
                     items(items = options.keys.toList(), key = { it }) { option ->
                         Row(
-                            verticalAlignment = Alignment.CenterVertically,
+                            verticalAlignment = CenterVertically,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
@@ -962,7 +969,7 @@ fun PasswordGenerationDialog(
                     }
 
                     Row(
-                        verticalAlignment = Alignment.CenterVertically,
+                        verticalAlignment = CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
@@ -979,7 +986,7 @@ fun PasswordGenerationDialog(
                     }
 
                     Row(
-                        verticalAlignment = Alignment.CenterVertically,
+                        verticalAlignment = CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -381,9 +381,9 @@ fun EditOtpDialog(
     val (secret, setSecret) = remember { mutableStateOf(currentOtp.secret) }
     val (type, setType) = remember { mutableStateOf(currentOtp.type) }
     val (algorithm, setAlgorithm) = remember { mutableStateOf(currentOtp.algorithm) }
-    val (digits, setDigits) = remember { mutableIntStateOf(currentOtp.digits) }
-    val (counter, setCounter) = remember { mutableIntStateOf(currentOtp.counter) }
-    val (period, setPeriod) = remember { mutableIntStateOf(currentOtp.period) }
+    val (digits, setDigits) = remember { mutableStateOf(currentOtp.digits.toString()) }
+    val (counter, setCounter) = remember { mutableStateOf(currentOtp.counter.toString()) }
+    val (period, setPeriod) = remember { mutableStateOf(currentOtp.period.toString()) }
 
     var typeMenuExpanded by remember { mutableStateOf(false) }
     var algorithmMenuExpanded by remember { mutableStateOf(false) }
@@ -495,32 +495,35 @@ fun EditOtpDialog(
 
                     OutlinedTextField(
                         modifier = Modifier.padding(bottom = 0.dp, top = 16.dp),
-                        value = digits.toString(),
-                        onValueChange = { if (it.toIntOrNull() != null) setDigits(it.toInt()) },
+                        value = digits,
+                        onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setDigits(it) },
                         singleLine = true,
                         maxLines = 1,
                         label = { Text(text = "Digits") },
+                        placeholder = { Text(text = "6") }
                     )
 
                     if (type == OTP.Companion.Type.HOTP) {
                         OutlinedTextField(
                             modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
-                            value = counter.toString(),
-                            onValueChange = { if (it.toIntOrNull() != null) setCounter(it.toInt()) },
+                            value = counter,
+                            onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setCounter(it) },
                             singleLine = true,
                             maxLines = 1,
                             label = { Text(text = "Counter") },
+                            placeholder = { Text(text = "0") }
                         )
                     }
 
                     if (type == OTP.Companion.Type.TOTP) {
                         OutlinedTextField(
                             modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
-                            value = period.toString(),
-                            onValueChange = { if (it.toIntOrNull() != null) setPeriod(it.toInt()) },
+                            value = period,
+                            onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setPeriod(it) },
                             singleLine = true,
                             maxLines = 1,
                             label = { Text(text = "Period") },
+                            placeholder = { Text(text = "30") }
                         )
                     }
                 }
@@ -531,7 +534,15 @@ fun EditOtpDialog(
                         if (secret.isBlank()) {
                             showEmptyError = true
                         } else {
-                            onSaveClick(OTP(secret, type, algorithm, digits, counter, period))
+                            onSaveClick(
+                                OTP(secret,
+                                    type,
+                                    algorithm,
+                                    digits.toIntOrNull() ?: 6,
+                                    counter.toIntOrNull() ?: 0,
+                                    period.toIntOrNull() ?: 30
+                                )
+                            )
                         }
                     },
                     modifier = Modifier

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
@@ -429,102 +430,118 @@ fun EditOtpDialog(
                         } else null
                     )
 
-                    ExposedDropdownMenuBox(
-                        expanded = typeMenuExpanded,
-                        onExpandedChange = { typeMenuExpanded = !typeMenuExpanded },
-                        modifier = Modifier.padding(bottom = 0.dp, top = 16.dp)
-                    ) {
-                        OutlinedTextField(
-                            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                            value = type.uppercase(),
-                            onValueChange = {},
-                            readOnly = true,
-                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
-                            label = { Text(text = "Type") },
-                            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
-                        )
+                    var showAdvancedOptions by rememberSaveable { mutableStateOf(false) }
 
-                        ExposedDropdownMenu(
+                    Row (modifier = Modifier
+                        .padding(top = 16.dp, bottom = 8.dp)
+                        .clickable(onClick = { showAdvancedOptions = !showAdvancedOptions })
+                    ) {
+                        Text(text = "Show advanced options")
+
+                        Icon(
+                            imageVector = if (showAdvancedOptions) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                            contentDescription = "Toggle advanced"
+                        )
+                    }
+
+                    if (showAdvancedOptions) {
+                        ExposedDropdownMenuBox(
                             expanded = typeMenuExpanded,
-                            onDismissRequest = { typeMenuExpanded = false }
+                            onExpandedChange = { typeMenuExpanded = !typeMenuExpanded },
+                            modifier = Modifier.padding(bottom = 0.dp, top = 16.dp)
                         ) {
-                            types.forEach { type ->
-                                DropdownMenuItem(
-                                    text = { Text(text = type.uppercase()) },
-                                    onClick = {
-                                        setType(type)
-                                        typeMenuExpanded = false
-                                    },
-                                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
-                                )
+                            OutlinedTextField(
+                                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                                value = type.uppercase(),
+                                onValueChange = {},
+                                readOnly = true,
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
+                                label = { Text(text = "Type") },
+                                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                            )
+
+                            ExposedDropdownMenu(
+                                expanded = typeMenuExpanded,
+                                onDismissRequest = { typeMenuExpanded = false }
+                            ) {
+                                types.forEach { type ->
+                                    DropdownMenuItem(
+                                        text = { Text(text = type.uppercase()) },
+                                        onClick = {
+                                            setType(type)
+                                            typeMenuExpanded = false
+                                        },
+                                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                    )
+                                }
                             }
                         }
-                    }
 
-                    ExposedDropdownMenuBox(
-                        expanded = algorithmMenuExpanded,
-                        onExpandedChange = { algorithmMenuExpanded = !algorithmMenuExpanded },
-                        modifier = Modifier.padding(bottom = 0.dp, top = 16.dp)
-                    ) {
-                        OutlinedTextField(
-                            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                            value = algorithm.uppercase(),
-                            onValueChange = {},
-                            readOnly = true,
-                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
-                            label = { Text(text = "Algorithm") },
-                            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
-                        )
-
-                        ExposedDropdownMenu(
+                        ExposedDropdownMenuBox(
                             expanded = algorithmMenuExpanded,
-                            onDismissRequest = { algorithmMenuExpanded = false }
+                            onExpandedChange = { algorithmMenuExpanded = !algorithmMenuExpanded },
+                            modifier = Modifier.padding(bottom = 0.dp, top = 16.dp)
                         ) {
-                            algorithms.forEach { algorithm ->
-                                DropdownMenuItem(
-                                    text = { Text(text = algorithm.uppercase()) },
-                                    onClick = {
-                                        setAlgorithm(algorithm)
-                                        algorithmMenuExpanded = false
-                                    },
-                                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
-                                )
+                            OutlinedTextField(
+                                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                                value = algorithm.uppercase(),
+                                onValueChange = {},
+                                readOnly = true,
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
+                                label = { Text(text = "Algorithm") },
+                                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                            )
+
+                            ExposedDropdownMenu(
+                                expanded = algorithmMenuExpanded,
+                                onDismissRequest = { algorithmMenuExpanded = false }
+                            ) {
+                                algorithms.forEach { algorithm ->
+                                    DropdownMenuItem(
+                                        text = { Text(text = algorithm.uppercase()) },
+                                        onClick = {
+                                            setAlgorithm(algorithm)
+                                            algorithmMenuExpanded = false
+                                        },
+                                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                    )
+                                }
                             }
                         }
-                    }
 
-                    OutlinedTextField(
-                        modifier = Modifier.padding(bottom = 0.dp, top = 16.dp),
-                        value = digits,
-                        onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setDigits(it) },
-                        singleLine = true,
-                        maxLines = 1,
-                        label = { Text(text = "Digits") },
-                        placeholder = { Text(text = "6") }
-                    )
-
-                    if (type == OTP.Companion.Type.HOTP) {
                         OutlinedTextField(
-                            modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
-                            value = counter,
-                            onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setCounter(it) },
+                            modifier = Modifier.padding(bottom = 0.dp, top = 16.dp),
+                            value = digits,
+                            onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setDigits(it) },
                             singleLine = true,
                             maxLines = 1,
-                            label = { Text(text = "Counter") },
-                            placeholder = { Text(text = "0") }
+                            label = { Text(text = "Digits") },
+                            placeholder = { Text(text = "6") }
                         )
-                    }
 
-                    if (type == OTP.Companion.Type.TOTP) {
-                        OutlinedTextField(
-                            modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
-                            value = period,
-                            onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setPeriod(it) },
-                            singleLine = true,
-                            maxLines = 1,
-                            label = { Text(text = "Period") },
-                            placeholder = { Text(text = "30") }
-                        )
+                        if (type == OTP.Companion.Type.HOTP) {
+                            OutlinedTextField(
+                                modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
+                                value = counter,
+                                onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setCounter(it) },
+                                singleLine = true,
+                                maxLines = 1,
+                                label = { Text(text = "Counter") },
+                                placeholder = { Text(text = "0") }
+                            )
+                        }
+
+                        if (type == OTP.Companion.Type.TOTP) {
+                            OutlinedTextField(
+                                modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
+                                value = period,
+                                onValueChange = { if (it.toIntOrNull() != null || it.isEmpty()) setPeriod(it) },
+                                singleLine = true,
+                                maxLines = 1,
+                                label = { Text(text = "Period") },
+                                placeholder = { Text(text = "30") }
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -556,7 +556,7 @@ fun EditOtpDialog(
                                 value = algorithms[algorithm] ?: "",
                                 onValueChange = {},
                                 readOnly = true,
-                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = algorithmMenuExpanded) },
                                 label = { Text(text = stringResource(R.string.otp_algorithm)) },
                                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
                             )

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -67,6 +67,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -466,11 +468,13 @@ fun EditOtpDialog(
                             rememberScrollState()
                         )
                 ) {
+                    var showSecret by rememberSaveable { mutableStateOf(false) }
                     OutlinedTextField(
                         value = secret,
                         onValueChange = setSecret,
                         singleLine = true,
                         maxLines = 1,
+                        textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily(Font(R.font.dejavu_sans_mono))),
                         label = { Text(text = stringResource(R.string.otp_secret)) },
                         isError = showInputErrors && (secret.isBlank() || !Base32().isInAlphabet(secret)),
                         supportingText = if (showInputErrors && secret.isBlank()) {
@@ -481,7 +485,18 @@ fun EditOtpDialog(
                             {
                                 Text(text = stringResource(R.string.error_invalid_secret))
                             }
-                        } else null
+                        } else null,
+                        visualTransformation = if (showSecret)
+                            VisualTransformation.None else PasswordVisualTransformation(),
+                        trailingIcon = {
+                            IconButton(onClick = { showSecret = !showSecret }) {
+                                Icon(
+                                    imageVector = if (showSecret)
+                                        Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                                    contentDescription = stringResource(R.string.text_input_show_secret_toggle)
+                                )
+                            }
+                        }
                     )
 
                     var showAdvancedOptions by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/Dialogs.kt
@@ -73,6 +73,7 @@ import com.hegocre.nextcloudpasswords.data.password.CustomField
 import com.hegocre.nextcloudpasswords.data.password.RequestedPassword
 import com.hegocre.nextcloudpasswords.ui.theme.ContentAlpha
 import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
+import com.hegocre.nextcloudpasswords.utils.OTP
 import com.hegocre.nextcloudpasswords.utils.PreferencesManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
@@ -346,6 +347,191 @@ fun AddCustomFieldDialog(
                             showEmptyError = true
                         } else {
                             onAddClick(type, label)
+                        }
+                    },
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(horizontal = 0.dp)
+                ) {
+                    Text(text = stringResource(android.R.string.ok))
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditOtpDialog(
+    onSaveClick: (OTP) -> Unit,
+    onDismissRequest: (() -> Unit)? = null,
+    currentOtp: OTP = OTP(secret = "")
+) {
+    val types = listOf(
+        OTP.Companion.Type.TOTP,
+        OTP.Companion.Type.HOTP
+    )
+
+    val algorithms = listOf(
+        OTP.Companion.Algorithm.SHA1,
+        OTP.Companion.Algorithm.SHA256,
+        OTP.Companion.Algorithm.SHA512
+    )
+
+    val (secret, setSecret) = remember { mutableStateOf(currentOtp.secret) }
+    val (type, setType) = remember { mutableStateOf(currentOtp.type) }
+    val (algorithm, setAlgorithm) = remember { mutableStateOf(currentOtp.algorithm) }
+    val (digits, setDigits) = remember { mutableIntStateOf(currentOtp.digits) }
+    val (counter, setCounter) = remember { mutableIntStateOf(currentOtp.counter) }
+    val (period, setPeriod) = remember { mutableIntStateOf(currentOtp.period) }
+
+    var typeMenuExpanded by remember { mutableStateOf(false) }
+    var algorithmMenuExpanded by remember { mutableStateOf(false) }
+
+    var showEmptyError by rememberSaveable {
+        mutableStateOf(false)
+    }
+
+    Dialog(
+        onDismissRequest = { onDismissRequest?.invoke() },
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.surface,
+            contentColor = contentColorFor(backgroundColor = MaterialTheme.colorScheme.surface),
+            shape = MaterialTheme.shapes.extraLarge,
+            tonalElevation = 6.dp,
+        ) {
+            Column(modifier = Modifier.padding(all = 24.dp)) {
+                Text(
+                    text = "OTP",
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+
+                Column(
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .verticalScroll(
+                            rememberScrollState()
+                        )
+                ) {
+                    OutlinedTextField(
+                        value = secret,
+                        onValueChange = setSecret,
+                        singleLine = true,
+                        maxLines = 1,
+                        label = { Text(text = "Secret") },
+                        isError = showEmptyError && secret.isBlank(),
+                        supportingText = if (showEmptyError && secret.isBlank()) {
+                            {
+                                Text(text = stringResource(id = R.string.error_field_cannot_be_empty))
+                            }
+                        } else null
+                    )
+
+                    ExposedDropdownMenuBox(
+                        expanded = typeMenuExpanded,
+                        onExpandedChange = { typeMenuExpanded = !typeMenuExpanded },
+                        modifier = Modifier.padding(bottom = 0.dp, top = 16.dp)
+                    ) {
+                        OutlinedTextField(
+                            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                            value = type.uppercase(),
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
+                            label = { Text(text = "Type") },
+                            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = typeMenuExpanded,
+                            onDismissRequest = { typeMenuExpanded = false }
+                        ) {
+                            types.forEach { type ->
+                                DropdownMenuItem(
+                                    text = { Text(text = type.uppercase()) },
+                                    onClick = {
+                                        setType(type)
+                                        typeMenuExpanded = false
+                                    },
+                                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                )
+                            }
+                        }
+                    }
+
+                    ExposedDropdownMenuBox(
+                        expanded = algorithmMenuExpanded,
+                        onExpandedChange = { algorithmMenuExpanded = !algorithmMenuExpanded },
+                        modifier = Modifier.padding(bottom = 0.dp, top = 16.dp)
+                    ) {
+                        OutlinedTextField(
+                            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                            value = algorithm.uppercase(),
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeMenuExpanded) },
+                            label = { Text(text = "Algorithm") },
+                            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = algorithmMenuExpanded,
+                            onDismissRequest = { algorithmMenuExpanded = false }
+                        ) {
+                            algorithms.forEach { algorithm ->
+                                DropdownMenuItem(
+                                    text = { Text(text = algorithm.uppercase()) },
+                                    onClick = {
+                                        setAlgorithm(algorithm)
+                                        algorithmMenuExpanded = false
+                                    },
+                                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                )
+                            }
+                        }
+                    }
+
+                    OutlinedTextField(
+                        modifier = Modifier.padding(bottom = 0.dp, top = 16.dp),
+                        value = digits.toString(),
+                        onValueChange = { if (it.toIntOrNull() != null) setDigits(it.toInt()) },
+                        singleLine = true,
+                        maxLines = 1,
+                        label = { Text(text = "Digits") },
+                    )
+
+                    if (type == OTP.Companion.Type.HOTP) {
+                        OutlinedTextField(
+                            modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
+                            value = counter.toString(),
+                            onValueChange = { if (it.toIntOrNull() != null) setCounter(it.toInt()) },
+                            singleLine = true,
+                            maxLines = 1,
+                            label = { Text(text = "Counter") },
+                        )
+                    }
+
+                    if (type == OTP.Companion.Type.TOTP) {
+                        OutlinedTextField(
+                            modifier = Modifier.padding(bottom = 8.dp, top = 16.dp),
+                            value = period.toString(),
+                            onValueChange = { if (it.toIntOrNull() != null) setPeriod(it.toInt()) },
+                            singleLine = true,
+                            maxLines = 1,
+                            label = { Text(text = "Period") },
+                        )
+                    }
+                }
+
+
+                TextButton(
+                    onClick = {
+                        if (secret.isBlank()) {
+                            showEmptyError = true
+                        } else {
+                            onSaveClick(OTP(secret, type, algorithm, digits, counter, period))
                         }
                     },
                     modifier = Modifier

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -59,6 +60,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hegocre.nextcloudpasswords.R
 import com.hegocre.nextcloudpasswords.api.FoldersApi
+import com.hegocre.nextcloudpasswords.data.serversettings.ServerSettings
 import com.hegocre.nextcloudpasswords.ui.NCPScreen
 import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
 import com.hegocre.nextcloudpasswords.ui.viewmodels.PasswordsViewModel
@@ -80,6 +82,9 @@ fun NextcloudPasswordsApp(
     val currentScreen = NCPScreen.fromRoute(
         backstackEntry.value?.destination?.route
     )
+
+    val keychain by passwordsViewModel.csEv1Keychain.observeAsState()
+    val serverSettings by passwordsViewModel.serverSettings.observeAsState(initial = ServerSettings())
 
     var openBottomSheet by rememberSaveable { mutableStateOf(false) }
     val modalSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -269,6 +274,47 @@ fun NextcloudPasswordsApp(
                     openBottomSheet = true
                 },
                 replyAutofill = replyAutofill,
+                createPassword = { newPassword, onSuccess, onFailure ->
+                    coroutineScope.launch {
+                        val newPwd = newPassword.let {
+                            val currentKeychain = keychain
+                            if (currentKeychain != null && serverSettings.encryptionCse != 0) {
+                                it.encrypt(currentKeychain.current, currentKeychain)
+                            } else it
+                        }
+
+                        if (passwordsViewModel.createPassword(newPwd).await()) {
+                            onSuccess()
+                        } else {
+                            onFailure()
+                        }
+                    }
+                },
+                updatePassword = { updatedPassword, onSuccess, onFailure ->
+                    coroutineScope.launch {
+                        val updatedPwd = updatedPassword.let {
+                            val currentKeychain = keychain
+                            if (currentKeychain != null && serverSettings.encryptionCse != 0) {
+                                it.encrypt(currentKeychain.current, currentKeychain)
+                            } else it
+                        }
+
+                        if (passwordsViewModel.updatePassword(updatedPwd).await()) {
+                            onSuccess()
+                        } else {
+                            onFailure()
+                        }
+                    }
+                },
+                deletePassword = { deletedPassword, onSuccess, onFailure ->
+                    coroutineScope.launch {
+                        if (passwordsViewModel.deletePassword(deletedPassword).await()) {
+                            onSuccess()
+                        } else {
+                            onFailure()
+                        }
+                    }
+                },
                 searchVisibility = searchExpanded,
                 closeSearch = {
                     searchExpanded = false

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
@@ -290,11 +290,11 @@ fun NextcloudPasswordsApp(
                         }
                     }
                 },
-                updatePassword = { updatedPassword, onSuccess, onFailure ->
+                updatePassword = { updatedPassword, shouldEncrypt, onSuccess, onFailure ->
                     coroutineScope.launch {
                         val updatedPwd = updatedPassword.let {
                             val currentKeychain = keychain
-                            if (currentKeychain != null && serverSettings.encryptionCse != 0) {
+                            if (shouldEncrypt && currentKeychain != null) {
                                 it.encrypt(currentKeychain.current, currentKeychain)
                             } else it
                         }
@@ -417,11 +417,11 @@ fun NextcloudPasswordsApp(
                                 navController.navigate("${NCPScreen.PasswordEdit.name}/${passwordsViewModel.visiblePassword.value?.first?.id ?: "none"}")
                             }
                         } else null,
-                        updatePassword = {updatedPassword, onSuccess, onFailure ->
+                        updatePassword = { updatedPassword, shouldEncrypt, onSuccess, onFailure ->
                             coroutineScope.launch {
                                 val updatedPwd = updatedPassword.let {
                                     val currentKeychain = keychain
-                                    if (currentKeychain != null && serverSettings.encryptionCse != 0) {
+                                    if (shouldEncrypt && currentKeychain != null) {
                                         it.encrypt(currentKeychain.current, currentKeychain)
                                     } else it
                                 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
@@ -417,6 +417,23 @@ fun NextcloudPasswordsApp(
                                 navController.navigate("${NCPScreen.PasswordEdit.name}/${passwordsViewModel.visiblePassword.value?.first?.id ?: "none"}")
                             }
                         } else null,
+                        updatePassword = {updatedPassword, onSuccess, onFailure ->
+                            coroutineScope.launch {
+                                val updatedPwd = updatedPassword.let {
+                                    val currentKeychain = keychain
+                                    if (currentKeychain != null && serverSettings.encryptionCse != 0) {
+                                        it.encrypt(currentKeychain.current, currentKeychain)
+                                    } else it
+                                }
+
+                                if (passwordsViewModel.updatePassword(updatedPwd).await()) {
+                                    onSuccess()
+                                } else {
+                                    onFailure()
+                                }
+                            }
+
+                        },
                         modifier = Modifier.padding(bottom = 16.dp)
                     )
                 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPApp.kt
@@ -85,6 +85,7 @@ fun NextcloudPasswordsApp(
 
     val keychain by passwordsViewModel.csEv1Keychain.observeAsState()
     val serverSettings by passwordsViewModel.serverSettings.observeAsState(initial = ServerSettings())
+    val passwords by passwordsViewModel.passwords.observeAsState(initial = listOf())
 
     var openBottomSheet by rememberSaveable { mutableStateOf(false) }
     val modalSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -403,8 +404,21 @@ fun NextcloudPasswordsApp(
                     contentWindowInsets = { WindowInsets.navigationBars },
                     sheetState = modalSheetState
                 ) {
+                    val currentPasswordInfo = passwordsViewModel.visiblePassword.value?.let { visible ->
+                        val updatedPassword = passwords.find { it.id == visible.first.id }
+                        if (updatedPassword != null) {
+                            Pair(
+                                // Update the revision, so that multiple HOTP counter updates work
+                                visible.first.copy(
+                                    revision = updatedPassword.revision,
+                                    updated = updatedPassword.updated,
+                                ),
+                                visible.second
+                            )
+                        } else visible
+                    }
                     PasswordItem(
-                        passwordInfo = passwordsViewModel.visiblePassword.value,
+                        passwordInfo = currentPasswordInfo,
                         onEditPassword = if (sessionOpen) {
                             {
                                 coroutineScope.launch {

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
@@ -59,6 +59,7 @@ import com.hegocre.nextcloudpasswords.utils.decryptPasswords
 import com.hegocre.nextcloudpasswords.utils.encryptValue
 import com.hegocre.nextcloudpasswords.utils.sha1Hash
 import com.hegocre.nextcloudpasswords.utils.AutofillData
+import com.hegocre.nextcloudpasswords.utils.copyToClipboard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -115,6 +116,14 @@ fun NCPNavHost(
     val onPasswordClick: (Password) -> Unit = { password ->
         when (autofillData) {
             is AutofillData.ChoosePwd if replyAutofill != null -> {
+                if (PreferencesManager.getInstance(context).getCopyOTPOnAutofill()) {
+                    val otp = password.getOTP()
+                    if (otp.second != null) {
+                        otp.first?.let { otpCode ->
+                            context.copyToClipboard(otpCode, isSensitive = true)
+                        }
+                    }
+                }
                 replyAutofill(password.label, password.username, password.password)
             }
             is AutofillData.Save, is AutofillData.SaveAutofill -> {
@@ -227,6 +236,14 @@ fun NCPNavHost(
                                         filteredPasswordList
                                             .firstOrNull { it.id == autofillData.id }
                                             ?.let {
+                                                if (PreferencesManager.getInstance(context).getCopyOTPOnAutofill()) {
+                                                    val otp = it.getOTP()
+                                                    if (otp.second != null) {
+                                                        otp.first?.let { otpCode ->
+                                                            context.copyToClipboard(otpCode, isSensitive = true)
+                                                        }
+                                                    }
+                                                }
                                                 replyAutofill(it.label, it.username, it.password)
                                             } 
                                             ?: NoContentText()

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
@@ -74,7 +74,7 @@ fun NCPNavHost(
     autofillData: AutofillData?,
     openPasswordDetails: (password: Password, folderTree: List<String>) -> Unit,
     createPassword: (newPassword: NewPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
-    updatePassword: (updatedPassword: UpdatedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
+    updatePassword: (updatedPassword: UpdatedPassword, shouldEncrypt: Boolean, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
     deletePassword: (deletedPassword: DeletedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
     replyAutofill: ((label: String, username: String, password: String) -> Unit)? = null,
     modalSheetState: SheetState? = null,
@@ -633,6 +633,7 @@ fun NCPNavHost(
 
                                             updatePassword(
                                                 updatedPassword,
+                                                selectedPassword.cseType == "CSEv1r1",
                                                 {
                                                     if (editablePasswordState.replyAutofill && replyAutofill != null) {
                                                         replyAutofill(

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPNavHost.kt
@@ -72,8 +72,11 @@ fun NCPNavHost(
     modifier: Modifier = Modifier,
     searchQuery: String = "",
     autofillData: AutofillData?,
-    openPasswordDetails: (Password, List<String>) -> Unit,
-    replyAutofill: ((String, String, String) -> Unit)? = null,
+    openPasswordDetails: (password: Password, folderTree: List<String>) -> Unit,
+    createPassword: (newPassword: NewPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
+    updatePassword: (updatedPassword: UpdatedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
+    deletePassword: (deletedPassword: DeletedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
+    replyAutofill: ((label: String, username: String, password: String) -> Unit)? = null,
     modalSheetState: SheetState? = null,
     searchVisibility: Boolean? = null,
     closeSearch: (() -> Unit)? = null,
@@ -566,71 +569,30 @@ fun NCPNavHost(
                                     editablePasswordState = editablePasswordState,
                                     folders = foldersDecryptionState.decryptedList ?: listOf(),
                                     onSavePassword = {
-                                        val currentKeychain = keychain
-
                                         val customFields =
                                             Json.encodeToString(editablePasswordState.customFields.toList())
 
-                                        if (selectedPassword == null) {
-                                            // New password
-                                            val newPassword =
-                                                if (currentKeychain != null && serverSettings.encryptionCse != 0) {
-                                                    NewPassword(
-                                                        password = editablePasswordState.password.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        label = editablePasswordState.label.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        username = editablePasswordState.username.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        url = editablePasswordState.url.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        notes = editablePasswordState.notes.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        customFields = customFields.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        hash = editablePasswordState.password.sha1Hash()
-                                                            .take(serverSettings.passwordSecurityHash),
-                                                        cseType = "CSEv1r1",
-                                                        cseKey = currentKeychain.current,
-                                                        folder = editablePasswordState.folder,
-                                                        edited = 0,
-                                                        hidden = false,
-                                                        favorite = editablePasswordState.favorite
-                                                    )
-                                                } else {
-                                                    NewPassword(
-                                                        password = editablePasswordState.password,
-                                                        label = editablePasswordState.label,
-                                                        username = editablePasswordState.username,
-                                                        url = editablePasswordState.url,
-                                                        notes = editablePasswordState.notes,
-                                                        customFields = customFields,
-                                                        hash = editablePasswordState.password.sha1Hash()
-                                                            .take(serverSettings.passwordSecurityHash),
-                                                        cseType = "none",
-                                                        cseKey = "",
-                                                        folder = editablePasswordState.folder,
-                                                        edited = 0,
-                                                        hidden = false,
-                                                        favorite = editablePasswordState.favorite
-                                                    )
-                                                }
-                                            coroutineScope.launch {
-                                                if (passwordsViewModel.createPassword(newPassword)
-                                                        .await()
-                                                ) {
+                                        if (selectedPassword == null) { // New password
+                                            val newPassword = NewPassword(
+                                                password = editablePasswordState.password,
+                                                label = editablePasswordState.label,
+                                                username = editablePasswordState.username,
+                                                url = editablePasswordState.url,
+                                                notes = editablePasswordState.notes,
+                                                customFields = customFields,
+                                                hash = editablePasswordState.password.sha1Hash()
+                                                    .take(serverSettings.passwordSecurityHash),
+                                                cseType = "none",
+                                                cseKey = "",
+                                                folder = editablePasswordState.folder,
+                                                edited = 0,
+                                                hidden = false,
+                                                favorite = editablePasswordState.favorite
+                                            )
+
+                                            createPassword(
+                                                newPassword,
+                                                {
                                                     if (editablePasswordState.replyAutofill && replyAutofill != null) {
                                                         replyAutofill(
                                                             editablePasswordState.label,
@@ -640,77 +602,38 @@ fun NCPNavHost(
                                                     } else {
                                                         navController.navigateUp()
                                                     }
-                                                } else {
+                                                },
+                                                {
                                                     Toast.makeText(
                                                         context,
                                                         R.string.error_password_saving_failed,
                                                         Toast.LENGTH_LONG
                                                     ).show()
                                                 }
-                                            }
+                                            )
                                         } else {
-                                            val updatedPassword =
-                                                if (currentKeychain != null && selectedPassword.cseType == "CSEv1r1") {
-                                                    UpdatedPassword(
-                                                        id = selectedPassword.id,
-                                                        revision = selectedPassword.revision,
-                                                        password = editablePasswordState.password.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        label = editablePasswordState.label.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        username = editablePasswordState.username.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        url = editablePasswordState.url.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        notes = editablePasswordState.notes.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        customFields = customFields.encryptValue(
-                                                            currentKeychain.current,
-                                                            currentKeychain
-                                                        ),
-                                                        hash = editablePasswordState.password.sha1Hash()
-                                                            .take(serverSettings.passwordSecurityHash),
-                                                        cseType = "CSEv1r1",
-                                                        cseKey = currentKeychain.current,
-                                                        folder = editablePasswordState.folder,
-                                                        edited = if (editablePasswordState.password == selectedPassword.password) selectedPassword.edited else 0,
-                                                        hidden = selectedPassword.hidden,
-                                                        favorite = editablePasswordState.favorite
-                                                    )
-                                                } else {
-                                                    UpdatedPassword(
-                                                        id = selectedPassword.id,
-                                                        revision = selectedPassword.revision,
-                                                        password = editablePasswordState.password,
-                                                        label = editablePasswordState.label,
-                                                        username = editablePasswordState.username,
-                                                        url = editablePasswordState.url,
-                                                        notes = editablePasswordState.notes,
-                                                        customFields = customFields,
-                                                        hash = editablePasswordState.password.sha1Hash()
-                                                            .take(serverSettings.passwordSecurityHash),
-                                                        cseType = "none",
-                                                        cseKey = "",
-                                                        folder = editablePasswordState.folder,
-                                                        edited = if (editablePasswordState.password == selectedPassword.password) selectedPassword.edited else 0,
-                                                        hidden = selectedPassword.hidden,
-                                                        favorite = editablePasswordState.favorite
-                                                    )
-                                                }
-                                            coroutineScope.launch {
-                                                if (passwordsViewModel.updatePassword(updatedPassword)
-                                                        .await()
-                                                ) {
+                                            val updatedPassword = UpdatedPassword(
+                                                id = selectedPassword.id,
+                                                revision = selectedPassword.revision,
+                                                password = editablePasswordState.password,
+                                                label = editablePasswordState.label,
+                                                username = editablePasswordState.username,
+                                                url = editablePasswordState.url,
+                                                notes = editablePasswordState.notes,
+                                                customFields = customFields,
+                                                hash = editablePasswordState.password.sha1Hash()
+                                                    .take(serverSettings.passwordSecurityHash),
+                                                cseType = "none",
+                                                cseKey = "",
+                                                folder = editablePasswordState.folder,
+                                                edited = if (editablePasswordState.password == selectedPassword.password) selectedPassword.edited else 0,
+                                                hidden = selectedPassword.hidden,
+                                                favorite = editablePasswordState.favorite
+                                            )
+
+                                            updatePassword(
+                                                updatedPassword,
+                                                {
                                                     if (editablePasswordState.replyAutofill && replyAutofill != null) {
                                                         replyAutofill(
                                                             editablePasswordState.label,
@@ -720,14 +643,15 @@ fun NCPNavHost(
                                                     } else {
                                                         navController.navigateUp()
                                                     }
-                                                } else {
+                                                },
+                                                {
                                                     Toast.makeText(
                                                         context,
                                                         R.string.error_password_saving_failed,
                                                         Toast.LENGTH_LONG
                                                     ).show()
                                                 }
-                                            }
+                                            )
                                         }
                                     },
                                     onDeletePassword = if (selectedPassword == null) null
@@ -737,19 +661,19 @@ fun NCPNavHost(
                                                 id = selectedPassword.id,
                                                 revision = selectedPassword.revision
                                             )
-                                            coroutineScope.launch {
-                                                if (passwordsViewModel.deletePassword(deletedPassword)
-                                                        .await()
-                                                ) {
+                                            deletePassword(
+                                                deletedPassword,
+                                                {
                                                     navController.navigateUp()
-                                                } else {
+                                                },
+                                                {
                                                     Toast.makeText(
                                                         context,
                                                         R.string.error_password_deleting_failed,
                                                         Toast.LENGTH_LONG
                                                     ).show()
                                                 }
-                                            }
+                                            )
                                         }
                                     },
                                     isUpdating = isUpdating,

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPSettings.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/NCPSettings.kt
@@ -412,6 +412,21 @@ fun NCPSettingsScreen(
                             enabled = !autofillEnabled
                         )
 
+                        var copyOtpOnAutofill by remember { mutableStateOf(preferencesManager.getCopyOTPOnAutofill()) }
+                        SwitchPreference(
+                            checked = copyOtpOnAutofill,
+                            onCheckedChange = { copy ->
+                                scope.launch(Dispatchers.IO) {
+                                    if (preferencesManager.setCopyOTPOnAutofill(copy)) {
+                                        copyOtpOnAutofill = copy
+                                    }
+                                }
+                            },
+                            title = { Text(stringResource(R.string.copy_otp_preference_title)) },
+                            subtitle = { Text(stringResource(R.string.copy_otp_preference_subtitle)) },
+                            enabled = autofillEnabled
+                        )
+
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                             var useInlineAutofill by remember { mutableStateOf(preferencesManager.getUseInlineAutofill()) }
 

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
@@ -206,7 +206,11 @@ fun EditablePasswordView(
         derivedStateOf {
             editablePasswordState.customFields.find { it.label == OTP.CUSTOM_FIELD_LABEL }
                 ?.let {
-                    Json.decodeFromString<OTP>(it.value)
+                    try {
+                        Json.decodeFromString<OTP>(it.value)
+                    } catch (_: Exception) {
+                        null
+                    }
                 }
         }
     }
@@ -386,7 +390,7 @@ fun EditablePasswordView(
         item (key = "password_custom_${OTP.CUSTOM_FIELD_LABEL}") {
             OutlinedClickableTextField(
                 value = otp?.secret ?: "",
-                label = "OTP",
+                label = stringResource(R.string.otp_title),
                 onClick = {
                     showOtpDialog = true
                 },

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
@@ -698,6 +698,13 @@ fun EditablePasswordView(
                 }
 
                 showOtpDialog = false
+            },
+            onDeleteClick = {
+                val index = editablePasswordState.customFields.indexOfFirst { it.label == OTP.CUSTOM_FIELD_LABEL }
+                if (index != -1) {
+                    editablePasswordState.customFields.removeAt(index)
+                }
+                showOtpDialog = false
             }
         )
     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
@@ -311,8 +311,6 @@ fun EditablePasswordView(
                 maxLines = 1,
                 trailingIcon = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-
-
                         if (isGenerating) {
                             CircularProgressIndicator(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -397,7 +395,9 @@ fun EditablePasswordView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 16.dp)
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = 16.dp),
+                visualTransformation = PasswordVisualTransformation(),
+                textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily(Font(R.font.dejavu_sans_mono))),
             )
         }
 

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -67,6 +68,7 @@ import com.hegocre.nextcloudpasswords.ui.theme.favoriteColor
 import com.hegocre.nextcloudpasswords.utils.isValidEmail
 import com.hegocre.nextcloudpasswords.utils.isValidURL
 import com.hegocre.nextcloudpasswords.utils.AutofillData
+import com.hegocre.nextcloudpasswords.utils.OTP
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.launch
@@ -166,6 +168,9 @@ fun EditablePasswordView(
     var showFolderDialog by rememberSaveable {
         mutableStateOf(false)
     }
+    var showOtpDialog by rememberSaveable {
+        mutableStateOf(false)
+    }
     var showFieldErrors by rememberSaveable {
         mutableStateOf(false)
     }
@@ -195,6 +200,15 @@ fun EditablePasswordView(
                 showDiscardDialog = false
             }
         )
+    }
+
+    val otp by remember {
+        derivedStateOf {
+            editablePasswordState.customFields.find { it.label == OTP.CUSTOM_FIELD_LABEL }
+                ?.let {
+                    Json.decodeFromString<OTP>(it.value)
+                }
+        }
     }
 
     LazyColumn {
@@ -369,6 +383,20 @@ fun EditablePasswordView(
             }
         }
 
+        item (key = "password_custom_${OTP.CUSTOM_FIELD_LABEL}") {
+            OutlinedClickableTextField(
+                value = otp?.secret ?: "Set OTP",
+                label = "OTP",
+                onClick = {
+                    showOtpDialog = true
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+                    .padding(horizontal = 16.dp)
+            )
+        }
+
         item(key = "password_url") {
             OutlinedTextField(
                 value = editablePasswordState.url,
@@ -410,7 +438,7 @@ fun EditablePasswordView(
         }
 
         itemsIndexed(
-            items = editablePasswordState.customFields,
+            items = editablePasswordState.customFields.filterNot { it.label == OTP.CUSTOM_FIELD_LABEL },
             key = { index, field -> "${index}_password_custom_${field.label}" }) { index, customField ->
             var showValue by rememberSaveable {
                 mutableStateOf(customField.type != CustomField.TYPE_SECRET)
@@ -645,6 +673,31 @@ fun EditablePasswordView(
             },
             onDismissRequest = {
                 showFolderDialog = false
+            }
+        )
+    }
+
+    if (showOtpDialog) {
+        EditOtpDialog(
+            currentOtp = otp ?: OTP(""),
+            onDismissRequest = {
+                showOtpDialog = false
+            },
+            onSaveClick = { otp ->
+                val json = Json { explicitNulls = false }
+                val newOtpField = CustomField(
+                    type = CustomField.TYPE_DATA,
+                    label = OTP.CUSTOM_FIELD_LABEL,
+                    value = json.encodeToString(otp)
+                )
+                val index = editablePasswordState.customFields.indexOfFirst { it.label == OTP.CUSTOM_FIELD_LABEL }
+                if (index != -1) {
+                    editablePasswordState.customFields[index] = newOtpField
+                } else {
+                    editablePasswordState.customFields.add(newOtpField)
+                }
+
+                showOtpDialog = false
             }
         )
     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
@@ -385,7 +385,7 @@ fun EditablePasswordView(
 
         item (key = "password_custom_${OTP.CUSTOM_FIELD_LABEL}") {
             OutlinedClickableTextField(
-                value = otp?.secret ?: "Set OTP",
+                value = otp?.secret ?: "",
                 label = "OTP",
                 onClick = {
                     showOtpDialog = true

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordEditView.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Casino
@@ -441,9 +441,9 @@ fun EditablePasswordView(
             )
         }
 
-        itemsIndexed(
-            items = editablePasswordState.customFields.filterNot { it.label == OTP.CUSTOM_FIELD_LABEL },
-            key = { index, field -> "${index}_password_custom_${field.label}" }) { index, customField ->
+        items(
+            items = editablePasswordState.customFields.withIndex().filterNot { it.value.label == OTP.CUSTOM_FIELD_LABEL },
+            key = { field -> "${field.index}_password_custom_${field.value.label}" }) { (index, customField) ->
             var showValue by rememberSaveable {
                 mutableStateOf(customField.type != CustomField.TYPE_SECRET)
             }
@@ -452,8 +452,7 @@ fun EditablePasswordView(
                 value = customField.value,
                 onValueChange = { newText ->
                     val newElement = editablePasswordState.customFields[index].copy(value = newText)
-                    editablePasswordState.customFields.removeAt(index)
-                    editablePasswordState.customFields.add(index, newElement)
+                    editablePasswordState.customFields[index] = newElement
                 },
                 textStyle = if (customField.type == CustomField.TYPE_SECRET)
                     LocalTextStyle.current.copy(fontFamily = FontFamily(Font(R.font.dejavu_sans_mono)))

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -315,46 +315,48 @@ fun PasswordItemContent(
                                         val newOtp = otpNotNull.getNext()
                                         otp = newOtp
 
-                                        customFields.indexOfFirst { it.label == OTP.CUSTOM_FIELD_LABEL }.let { otpIndex ->
-                                            if (otpIndex != -1) {
-                                                val newCustomFields = customFields.toMutableList()
-                                                newCustomFields[otpIndex] = CustomField(
-                                                    label = OTP.CUSTOM_FIELD_LABEL,
-                                                    type = CustomField.TYPE_DATA,
-                                                    value = Json.encodeToString(newOtp),
-                                                )
-                                                val encodedCustomFields = Json.encodeToString(newCustomFields)
+                                        if (password.editable) {
+                                            customFields.indexOfFirst { it.label == OTP.CUSTOM_FIELD_LABEL }.let { otpIndex ->
+                                                if (otpIndex != -1) {
+                                                    val newCustomFields = customFields.toMutableList()
+                                                    newCustomFields[otpIndex] = CustomField(
+                                                        label = OTP.CUSTOM_FIELD_LABEL,
+                                                        type = CustomField.TYPE_DATA,
+                                                        value = Json.encodeToString(newOtp),
+                                                    )
+                                                    val encodedCustomFields = Json.encodeToString(newCustomFields)
 
-                                                val updatedPassword = UpdatedPassword(
-                                                    id = password.id,
-                                                    revision = password.revision,
-                                                    password = password.password,
-                                                    label = password.label,
-                                                    username = password.username,
-                                                    url = password.url,
-                                                    notes = password.notes,
-                                                    customFields = encodedCustomFields,
-                                                    hash = password.hash,
-                                                    cseType = "none",
-                                                    cseKey = "",
-                                                    folder = password.folder,
-                                                    edited = password.edited,
-                                                    hidden = password.hidden,
-                                                    favorite = password.favorite
-                                                )
+                                                    val updatedPassword = UpdatedPassword(
+                                                        id = password.id,
+                                                        revision = password.revision,
+                                                        password = password.password,
+                                                        label = password.label,
+                                                        username = password.username,
+                                                        url = password.url,
+                                                        notes = password.notes,
+                                                        customFields = encodedCustomFields,
+                                                        hash = password.hash,
+                                                        cseType = "none",
+                                                        cseKey = "",
+                                                        folder = password.folder,
+                                                        edited = password.edited,
+                                                        hidden = password.hidden,
+                                                        favorite = password.favorite
+                                                    )
 
-                                                updatePassword(
-                                                    updatedPassword,
-                                                    password.cseType == "CSEv1r1",
-                                                    {},
-                                                    {
-                                                        Toast.makeText(
-                                                            context,
-                                                            resources.getString(R.string.error_could_not_sync_counter),
-                                                            Toast.LENGTH_LONG
-                                                        ).show()
-                                                    }
-                                                )
+                                                    updatePassword(
+                                                        updatedPassword,
+                                                        password.cseType == "CSEv1r1",
+                                                        {},
+                                                        {
+                                                            Toast.makeText(
+                                                                context,
+                                                                resources.getString(R.string.error_could_not_sync_counter),
+                                                                Toast.LENGTH_LONG
+                                                            ).show()
+                                                        }
+                                                    )
+                                                }
                                             }
                                         }
                                     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -655,7 +655,7 @@ fun PasswordOtpField(
                     IconButton(onClick = onGenerateNext) {
                         Icon(
                             imageVector = Icons.Default.Autorenew,
-                            contentDescription = stringResource(id = R.string.action_copy_value)
+                            contentDescription = stringResource(id = R.string.generate_next_otp_htop)
                         )
                     }
                 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -38,13 +39,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -68,6 +66,7 @@ import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
 import com.hegocre.nextcloudpasswords.ui.theme.favoriteColor
 import com.hegocre.nextcloudpasswords.utils.OTP
 import com.hegocre.nextcloudpasswords.utils.copyToClipboard
+import com.hegocre.nextcloudpasswords.utils.formatOtp
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import org.commonmark.node.Document
@@ -285,13 +284,13 @@ fun PasswordItemContent(
 
                     var currentOtp by remember { mutableStateOf(otp.getCurrent()) }
                     currentOtp.first?.let { code ->
-                        PasswordOtpField(text = code, label = "OTP", progress)
+                        PasswordOtpField(otp = code, label = "OTP", progress)
                         currentOtp.second?.let { endTimeInMillis ->
                             LaunchedEffect(endTimeInMillis) {
                                 while (System.currentTimeMillis() < endTimeInMillis) {
                                     val remaining = endTimeInMillis - System.currentTimeMillis()
                                     progress = 1f - (remaining.toFloat() / (otp.period.toFloat() * 1000f))
-                                    delay(timeMillis = 1L)
+                                    delay(timeMillis = 50L)
                                 }
                                 currentOtp = otp.getCurrent()
                             }
@@ -545,7 +544,7 @@ fun PasswordTextField(
 
 @Composable
 fun PasswordOtpField(
-    text: String,
+    otp: String,
     label: String,
     progress: Float?,
     modifier: Modifier = Modifier,
@@ -555,7 +554,7 @@ fun PasswordOtpField(
     ListItem(
         headlineContent = {
             Text(
-                text = text,
+                text = otp.formatOtp(),
                 maxLines = 1,
                 fontFamily = fontFamily,
                 modifier = Modifier
@@ -582,8 +581,13 @@ fun PasswordOtpField(
                 progress?.let {
                     CircularProgressIndicator(
                         progress = { it },
-                        modifier = Modifier.padding(end = 16.dp).width(24.dp).align(CenterVertically),
-                        trackColor = Color.Transparent
+                        modifier = Modifier
+                            .align(CenterVertically)
+                            .padding(end = 16.dp)
+                            .width(20.dp)
+                            .height(20.dp),
+                        trackColor = Color.Transparent,
+                        strokeWidth = 2.dp
                     )
                 }
 
@@ -591,7 +595,7 @@ fun PasswordOtpField(
                 val copiedText = stringResource(R.string.copied)
 
                 IconButton(onClick = {
-                    context.copyToClipboard(text, isSensitive = true)
+                    context.copyToClipboard(otp, isSensitive = true)
                     Toast.makeText(
                         context,
                         String.format(copiedText, "OTP"),
@@ -651,7 +655,7 @@ fun PasswordItemPreview() {
                     notes = "# This is a note\n\nIt is very important that this is read by all __means__\n\n" +
                             "## Subsection \n\n This is also important.\n\n" +
                             "## Another subsection\n\n### Even deeper\n\n Some text\nSome more text",
-                    customFields = "",
+                    customFields = "[{\"label\":\"client.ios.otp\",\"type\":\"data\",\"value\":\"{\\\"secret\\\": \\\"hello\\\"}\"}]",
                     status = 0,
                     statusCode = "GOOD",
                     hash = "",

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -303,6 +303,15 @@ fun PasswordItemContent(
                         }
                         currentOtp.first?.let { code ->
                             var progress by remember { mutableStateOf<Float?>(null) }
+                            var waitingForNewRevision by remember(password.id) { mutableStateOf(false) }
+                            var initialRevision by remember(password.id) { mutableStateOf(password.revision) }
+
+                            LaunchedEffect(password.revision) {
+                                if (password.revision != initialRevision) {
+                                    waitingForNewRevision = false
+                                    initialRevision = password.revision
+                                }
+                            }
 
                             val resources = LocalResources.current
 
@@ -310,8 +319,11 @@ fun PasswordItemContent(
                                 otp = code,
                                 label = stringResource(R.string.otp_title),
                                 progress = progress,
-                                onGenerateNext = if (currentOtp.second == null && otpNotNull.type == OTP.Companion.Type.HOTP) {
+                                isSyncing = waitingForNewRevision,
+                                onGenerateNext = if (!waitingForNewRevision && currentOtp.second == null && otpNotNull.type == OTP.Companion.Type.HOTP) {
                                     {
+                                        waitingForNewRevision = true
+                                        initialRevision = password.revision
                                         val newOtp = otpNotNull.getNext()
                                         otp = newOtp
 
@@ -349,6 +361,7 @@ fun PasswordItemContent(
                                                         password.cseType == "CSEv1r1",
                                                         {},
                                                         {
+                                                            waitingForNewRevision = false
                                                             Toast.makeText(
                                                                 context,
                                                                 resources.getString(R.string.error_could_not_sync_counter),
@@ -356,8 +369,12 @@ fun PasswordItemContent(
                                                             ).show()
                                                         }
                                                     )
+                                                } else {
+                                                    waitingForNewRevision = false
                                                 }
                                             }
+                                        } else {
+                                            waitingForNewRevision = false
                                         }
                                     }
                                 } else null
@@ -630,6 +647,7 @@ fun PasswordOtpField(
     progress: Float?,
     onGenerateNext: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    isSyncing: Boolean = false,
     onClickText: (() -> Unit)? = null,
     fontFamily: FontFamily? = null,
 ) {
@@ -660,12 +678,24 @@ fun PasswordOtpField(
         },
         trailingContent = {
             Row {
-                onGenerateNext?.let { onGenerateNext ->
-                    IconButton(onClick = onGenerateNext) {
-                        Icon(
-                            imageVector = Icons.Default.Autorenew,
-                            contentDescription = stringResource(id = R.string.generate_next_otp_htop)
-                        )
+                if (isSyncing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(CenterVertically)
+                            .padding(end = 16.dp)
+                            .width(20.dp)
+                            .height(20.dp),
+                        trackColor = Color.Transparent,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    onGenerateNext?.let { onGenerateNext ->
+                        IconButton(onClick = onGenerateNext) {
+                            Icon(
+                                imageVector = Icons.Default.Autorenew,
+                                contentDescription = stringResource(id = R.string.generate_next_otp_htop)
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.InlineTextContent
@@ -23,6 +24,8 @@ import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.Link
 import androidx.compose.material.icons.twotone.Password
 import androidx.compose.material.icons.twotone.Shield
+import androidx.compose.material.icons.twotone.Timelapse
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -32,12 +35,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -59,7 +66,9 @@ import com.hegocre.nextcloudpasswords.ui.components.markdown.MDDocument
 import com.hegocre.nextcloudpasswords.ui.theme.ContentAlpha
 import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
 import com.hegocre.nextcloudpasswords.ui.theme.favoriteColor
+import com.hegocre.nextcloudpasswords.utils.OTP
 import com.hegocre.nextcloudpasswords.utils.copyToClipboard
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import org.commonmark.node.Document
 import org.commonmark.parser.Parser
@@ -266,6 +275,31 @@ fun PasswordItemContent(
                 )
             }
 
+            val customFieldOtp by derivedStateOf { customFields.find { it.label == OTP.CUSTOM_FIELD_LABEL } }
+            customFieldOtp?.let { otpField ->
+                item(key = "${password.id}_otp") {
+                    val otp = remember(otpField) {
+                        Json.decodeFromString<OTP>(otpField.value)
+                    }
+                    var progress by remember { mutableStateOf<Float?>(null) }
+
+                    var currentOtp by remember { mutableStateOf(otp.getCurrent()) }
+                    currentOtp.first?.let { code ->
+                        PasswordOtpField(text = code, label = "OTP", progress)
+                        currentOtp.second?.let { endTimeInMillis ->
+                            LaunchedEffect(endTimeInMillis) {
+                                while (System.currentTimeMillis() < endTimeInMillis) {
+                                    val remaining = endTimeInMillis - System.currentTimeMillis()
+                                    progress = 1f - (remaining.toFloat() / (otp.period.toFloat() * 1000f))
+                                    delay(timeMillis = 1L)
+                                }
+                                currentOtp = otp.getCurrent()
+                            }
+                        }
+                    }
+                }
+            }
+
             if (password.url.isNotBlank()) {
                 item(key = "${password.id}_url") {
                     val urlLabel = stringResource(id = R.string.password_attr_url)
@@ -323,9 +357,10 @@ fun PasswordItemContent(
                 }
             }
 
-            if (customFields.isNotEmpty()) {
+            val customFieldsNoOtp by derivedStateOf { customFields.filterNot { it.label == OTP.CUSTOM_FIELD_LABEL } }
+            if (customFieldsNoOtp.isNotEmpty()) {
                 itemsIndexed(
-                    items = customFields,
+                    items = customFieldsNoOtp,
                     key = { index, field -> "${index}_${password.id}_${field.label}" }) {_, customField ->
                     when (customField.type) {
                         CustomField.TYPE_TEXT, CustomField.TYPE_EMAIL -> {
@@ -503,6 +538,73 @@ fun PasswordTextField(
         },
         leadingContent = icon,
         trailingContent = trailingIcon,
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        modifier = modifier
+    )
+}
+
+@Composable
+fun PasswordOtpField(
+    text: String,
+    label: String,
+    progress: Float?,
+    modifier: Modifier = Modifier,
+    onClickText: (() -> Unit)? = null,
+    fontFamily: FontFamily? = null,
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = text,
+                maxLines = 1,
+                fontFamily = fontFamily,
+                modifier = Modifier
+                    .clickable(
+                        enabled = onClickText != null,
+                        onClick = onClickText ?: {}
+                    ),
+            )
+        },
+        overlineContent = {
+            Text(
+                text = label.uppercase(),
+                maxLines = 1
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.TwoTone.Timelapse,
+                contentDescription = "OTP"
+            )
+        },
+        trailingContent = {
+            Row {
+                progress?.let {
+                    CircularProgressIndicator(
+                        progress = { it },
+                        modifier = Modifier.padding(end = 16.dp).width(24.dp).align(CenterVertically),
+                        trackColor = Color.Transparent
+                    )
+                }
+
+                val context = LocalContext.current
+                val copiedText = stringResource(R.string.copied)
+
+                IconButton(onClick = {
+                    context.copyToClipboard(text, isSensitive = true)
+                    Toast.makeText(
+                        context,
+                        String.format(copiedText, "OTP"),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }) {
+                    Icon(
+                        imageVector = Icons.TwoTone.ContentCopy,
+                        contentDescription = stringResource(id = R.string.action_copy_value)
+                    )
+                }
+            }
+        },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         modifier = modifier
     )

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -278,21 +278,29 @@ fun PasswordItemContent(
             customFieldOtp?.let { otpField ->
                 item(key = "${password.id}_otp") {
                     val otp = remember(otpField) {
-                        Json.decodeFromString<OTP>(otpField.value)
+                        try {
+                            Json.decodeFromString<OTP>(otpField.value)
+                        } catch (_: Exception) {
+                            null
+                        }
                     }
-                    var progress by remember { mutableStateOf<Float?>(null) }
 
-                    var currentOtp by remember { mutableStateOf(otp.getCurrent()) }
-                    currentOtp.first?.let { code ->
-                        PasswordOtpField(otp = code, label = "OTP", progress)
-                        currentOtp.second?.let { endTimeInMillis ->
-                            LaunchedEffect(endTimeInMillis) {
-                                while (System.currentTimeMillis() < endTimeInMillis) {
-                                    val remaining = endTimeInMillis - System.currentTimeMillis()
-                                    progress = 1f - (remaining.toFloat() / (otp.period.toFloat() * 1000f))
-                                    delay(timeMillis = 50L)
+                    otp?.let { otp ->
+                        var currentOtp by remember { mutableStateOf(otp.getCurrent()) }
+                        currentOtp.first?.let { code ->
+                            var progress by remember { mutableStateOf<Float?>(null) }
+
+                            PasswordOtpField(otp = code, label = stringResource(R.string.otp_title), progress)
+
+                            currentOtp.second?.let { endTimeInMillis ->
+                                LaunchedEffect(endTimeInMillis) {
+                                    while (System.currentTimeMillis() < endTimeInMillis) {
+                                        val remaining = endTimeInMillis - System.currentTimeMillis()
+                                        progress = 1f - (remaining.toFloat() / (otp.period.toFloat() * 1000f))
+                                        delay(timeMillis = 50L)
+                                    }
+                                    currentOtp = otp.getCurrent()
                                 }
-                                currentOtp = otp.getCurrent()
                             }
                         }
                     }
@@ -573,7 +581,7 @@ fun PasswordOtpField(
         leadingContent = {
             Icon(
                 imageVector = Icons.TwoTone.Timelapse,
-                contentDescription = "OTP"
+                contentDescription = stringResource(R.string.otp_title)
             )
         },
         trailingContent = {
@@ -593,12 +601,13 @@ fun PasswordOtpField(
 
                 val context = LocalContext.current
                 val copiedText = stringResource(R.string.copied)
+                val otpTitle = stringResource(R.string.otp_title)
 
                 IconButton(onClick = {
                     context.copyToClipboard(otp, isSensitive = true)
                     Toast.makeText(
                         context,
-                        String.format(copiedText, "OTP"),
+                        String.format(copiedText, otpTitle),
                         Toast.LENGTH_SHORT
                     ).show()
                 }) {

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -79,7 +79,7 @@ import org.commonmark.parser.Parser
 fun PasswordItem(
     passwordInfo: Pair<Password, List<String>>?,
     modifier: Modifier = Modifier,
-    updatePassword: (updatedPassword: UpdatedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
+    updatePassword: (updatedPassword: UpdatedPassword, shouldEncrypt: Boolean, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
     onEditPassword: (() -> Unit)? = null,
 ) {
     passwordInfo?.let { pass ->
@@ -100,7 +100,7 @@ fun PasswordItem(
 fun PasswordItemContent(
     passwordInfo: Pair<Password, List<String>>,
     onEditPassword: (() -> Unit)?,
-    updatePassword: (updatedPassword: UpdatedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
+    updatePassword: (updatedPassword: UpdatedPassword, shouldEncrypt: Boolean, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -345,6 +345,7 @@ fun PasswordItemContent(
 
                                                 updatePassword(
                                                     updatedPassword,
+                                                    password.cseType == "CSEv1r1",
                                                     {},
                                                     {
                                                         Toast.makeText(
@@ -767,7 +768,7 @@ fun PasswordItemPreview() {
                 ),
                 onEditPassword = {},
                 modifier = Modifier.padding(bottom = 16.dp),
-                updatePassword = { _, _, _ -> }
+                updatePassword = { _, _, _, _ -> }
             )
         }
     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -693,7 +693,7 @@ fun PasswordOtpField(
                         IconButton(onClick = onGenerateNext) {
                             Icon(
                                 imageVector = Icons.Default.Autorenew,
-                                contentDescription = stringResource(id = R.string.generate_next_otp_htop)
+                                contentDescription = stringResource(id = R.string.generate_next_otp_hotp)
                             )
                         }
                     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -122,9 +122,13 @@ fun PasswordItemContent(
 
     val customFields by remember {
         derivedStateOf {
-            if (password.customFields.isNotBlank()) {
-                Json.decodeFromString<List<CustomField>>(password.customFields)
-            } else {
+            try {
+                if (password.customFields.isNotBlank()) {
+                    Json.decodeFromString<List<CustomField>>(password.customFields)
+                } else {
+                    listOf()
+                }
+            } catch (_: Exception) {
                 listOf()
             }
         }
@@ -294,7 +298,9 @@ fun PasswordItemContent(
                     }
 
                     otp?.let { otpNotNull ->
-                        var currentOtp by remember(otpNotNull) { mutableStateOf(otpNotNull.getCurrent()) }
+                        var currentOtp by remember(otpNotNull) {
+                            mutableStateOf(runCatching { otpNotNull.getCurrent() }.getOrElse { Pair(null, null) })
+                        }
                         currentOtp.first?.let { code ->
                             var progress by remember { mutableStateOf<Float?>(null) }
 

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/ui/components/PasswordItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Star
@@ -47,6 +48,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.Placeholder
@@ -60,6 +62,7 @@ import androidx.compose.ui.unit.dp
 import com.hegocre.nextcloudpasswords.R
 import com.hegocre.nextcloudpasswords.data.password.CustomField
 import com.hegocre.nextcloudpasswords.data.password.Password
+import com.hegocre.nextcloudpasswords.data.password.UpdatedPassword
 import com.hegocre.nextcloudpasswords.ui.components.markdown.MDDocument
 import com.hegocre.nextcloudpasswords.ui.theme.ContentAlpha
 import com.hegocre.nextcloudpasswords.ui.theme.NextcloudPasswordsTheme
@@ -76,12 +79,14 @@ import org.commonmark.parser.Parser
 fun PasswordItem(
     passwordInfo: Pair<Password, List<String>>?,
     modifier: Modifier = Modifier,
+    updatePassword: (updatedPassword: UpdatedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
     onEditPassword: (() -> Unit)? = null,
 ) {
     passwordInfo?.let { pass ->
         PasswordItemContent(
             passwordInfo = pass,
             onEditPassword = onEditPassword,
+            updatePassword = updatePassword,
             modifier = modifier
         )
     } ?: Text(
@@ -95,6 +100,7 @@ fun PasswordItem(
 fun PasswordItemContent(
     passwordInfo: Pair<Password, List<String>>,
     onEditPassword: (() -> Unit)?,
+    updatePassword: (updatedPassword: UpdatedPassword, onSuccess: () -> Unit, onFailure: () -> Unit) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -277,29 +283,87 @@ fun PasswordItemContent(
             val customFieldOtp by derivedStateOf { customFields.find { it.label == OTP.CUSTOM_FIELD_LABEL } }
             customFieldOtp?.let { otpField ->
                 item(key = "${password.id}_otp") {
-                    val otp = remember(otpField) {
-                        try {
-                            Json.decodeFromString<OTP>(otpField.value)
-                        } catch (_: Exception) {
-                            null
-                        }
+                    var otp by remember(otpField) {
+                        mutableStateOf(
+                            try {
+                                Json.decodeFromString<OTP>(otpField.value)
+                            } catch (_: Exception) {
+                                null
+                            }
+                        )
                     }
 
-                    otp?.let { otp ->
-                        var currentOtp by remember { mutableStateOf(otp.getCurrent()) }
+                    otp?.let { otpNotNull ->
+                        var currentOtp by remember(otpNotNull) { mutableStateOf(otpNotNull.getCurrent()) }
                         currentOtp.first?.let { code ->
                             var progress by remember { mutableStateOf<Float?>(null) }
 
-                            PasswordOtpField(otp = code, label = stringResource(R.string.otp_title), progress)
+                            val resources = LocalResources.current
+
+                            PasswordOtpField(
+                                otp = code,
+                                label = stringResource(R.string.otp_title),
+                                progress = progress,
+                                onGenerateNext = if (currentOtp.second == null && otpNotNull.type == OTP.Companion.Type.HOTP) {
+                                    {
+                                        val newOtp = otpNotNull.getNext()
+                                        otp = newOtp
+
+                                        customFields.indexOfFirst { it.label == OTP.CUSTOM_FIELD_LABEL }.let { otpIndex ->
+                                            if (otpIndex != -1) {
+                                                val newCustomFields = customFields.toMutableList()
+                                                newCustomFields[otpIndex] = CustomField(
+                                                    label = OTP.CUSTOM_FIELD_LABEL,
+                                                    type = CustomField.TYPE_DATA,
+                                                    value = Json.encodeToString(newOtp),
+                                                )
+                                                val encodedCustomFields = Json.encodeToString(newCustomFields)
+
+                                                val updatedPassword = UpdatedPassword(
+                                                    id = password.id,
+                                                    revision = password.revision,
+                                                    password = password.password,
+                                                    label = password.label,
+                                                    username = password.username,
+                                                    url = password.url,
+                                                    notes = password.notes,
+                                                    customFields = encodedCustomFields,
+                                                    hash = password.hash,
+                                                    cseType = "none",
+                                                    cseKey = "",
+                                                    folder = password.folder,
+                                                    edited = password.edited,
+                                                    hidden = password.hidden,
+                                                    favorite = password.favorite
+                                                )
+
+                                                updatePassword(
+                                                    updatedPassword,
+                                                    {},
+                                                    {
+                                                        Toast.makeText(
+                                                            context,
+                                                            resources.getString(R.string.error_could_not_sync_counter),
+                                                            Toast.LENGTH_LONG
+                                                        ).show()
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    }
+                                } else null
+                            )
 
                             currentOtp.second?.let { endTimeInMillis ->
-                                LaunchedEffect(endTimeInMillis) {
-                                    while (System.currentTimeMillis() < endTimeInMillis) {
-                                        val remaining = endTimeInMillis - System.currentTimeMillis()
-                                        progress = 1f - (remaining.toFloat() / (otp.period.toFloat() * 1000f))
-                                        delay(timeMillis = 50L)
+                                if (otpNotNull.type == OTP.Companion.Type.TOTP) {
+                                    LaunchedEffect(endTimeInMillis) {
+                                        while (System.currentTimeMillis() < endTimeInMillis) {
+                                            val remaining = endTimeInMillis - System.currentTimeMillis()
+                                            progress = 1f - (remaining.toFloat() / (otpNotNull.period.toFloat() * 1000f))
+                                            delay(timeMillis = 50L)
+                                        }
+                                        currentOtp = otpNotNull.getCurrent()
                                     }
-                                    currentOtp = otp.getCurrent()
                                 }
                             }
                         }
@@ -555,6 +619,7 @@ fun PasswordOtpField(
     otp: String,
     label: String,
     progress: Float?,
+    onGenerateNext: (() -> Unit)?,
     modifier: Modifier = Modifier,
     onClickText: (() -> Unit)? = null,
     fontFamily: FontFamily? = null,
@@ -586,6 +651,15 @@ fun PasswordOtpField(
         },
         trailingContent = {
             Row {
+                onGenerateNext?.let { onGenerateNext ->
+                    IconButton(onClick = onGenerateNext) {
+                        Icon(
+                            imageVector = Icons.Default.Autorenew,
+                            contentDescription = stringResource(id = R.string.action_copy_value)
+                        )
+                    }
+                }
+
                 progress?.let {
                     CircularProgressIndicator(
                         progress = { it },
@@ -656,37 +730,38 @@ fun PasswordItemPreview() {
             PasswordItem(
                 passwordInfo = Pair(
                     Password(
-                    id = "",
-                    label = "Nextcloud with a really long label",
-                    username = "john_doe",
-                    password = "secret_value",
-                    url = "https://nextcloud.com/",
-                    notes = "# This is a note\n\nIt is very important that this is read by all __means__\n\n" +
-                            "## Subsection \n\n This is also important.\n\n" +
-                            "## Another subsection\n\n### Even deeper\n\n Some text\nSome more text",
-                    customFields = "[{\"label\":\"client.ios.otp\",\"type\":\"data\",\"value\":\"{\\\"secret\\\": \\\"hello\\\"}\"}]",
-                    status = 0,
-                    statusCode = "GOOD",
-                    hash = "",
-                    folder = "",
-                    revision = "",
-                    share = null,
-                    shared = false,
-                    cseType = "",
-                    cseKey = "",
-                    sseType = "",
-                    client = "",
-                    hidden = false,
-                    trashed = false,
-                    favorite = true,
-                    editable = true,
-                    edited = 0,
-                    created = 0,
-                    updated = 0
+                        id = "",
+                        label = "Nextcloud with a really long label",
+                        username = "john_doe",
+                        password = "secret_value",
+                        url = "https://nextcloud.com/",
+                        notes = "# This is a note\n\nIt is very important that this is read by all __means__\n\n" +
+                                "## Subsection \n\n This is also important.\n\n" +
+                                "## Another subsection\n\n### Even deeper\n\n Some text\nSome more text",
+                        customFields = "[{\"label\":\"client.ios.otp\",\"type\":\"data\",\"value\":\"{\\\"secret\\\": \\\"hello\\\"}\"}]",
+                        status = 0,
+                        statusCode = "GOOD",
+                        hash = "",
+                        folder = "",
+                        revision = "",
+                        share = null,
+                        shared = false,
+                        cseType = "",
+                        cseKey = "",
+                        sseType = "",
+                        client = "",
+                        hidden = false,
+                        trashed = false,
+                        favorite = true,
+                        editable = true,
+                        edited = 0,
+                        created = 0,
+                        updated = 0
                     ), listOf("Second", "Home")
                 ),
                 onEditPassword = {},
-                modifier = Modifier.padding(bottom = 16.dp)
+                modifier = Modifier.padding(bottom = 16.dp),
+                updatePassword = { _, _, _ -> }
             )
         }
     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -11,6 +11,7 @@ import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordGenerato
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+import org.apache.commons.codec.DecoderException
 import org.apache.commons.codec.binary.Base32
 import java.util.concurrent.TimeUnit
 
@@ -107,7 +108,7 @@ data class OTP(
             val secret = uri.getQueryParameter("secret")
                 ?: throw OtpParseException.MissingSecret()
 
-            if (!Base32().isInAlphabet(secret)) {
+            if (!secret.isValidSecret()) {
                 throw OtpParseException.InvalidSecret()
             }
 
@@ -170,4 +171,54 @@ fun String.formatOtp(chunkSize: Int? = null): String {
     }
 
     return digitsOnly.chunked(size).joinToString(" ")
+}
+
+fun String.isValidSecret(): Boolean {
+    val normalized = this
+        .trim()
+        .replace("-", "")
+        .replace(" ", "")
+        .uppercase()
+
+    if (normalized.isEmpty()) {
+        return false
+    }
+
+    val base32Pattern = Regex("^[A-Z2-7]+=*$")
+    if (!base32Pattern.matches(normalized)) {
+        return false
+    }
+
+    val padded = padBase32(normalized)
+
+    val decoded = try {
+        val base32 = Base32()
+        if (!base32.isInAlphabet(padded)) {
+            return false
+        }
+        base32.decode(padded)
+    } catch (_: DecoderException) {
+        return false
+    } catch (_: IllegalArgumentException) {
+        return false
+    }
+
+    if (decoded.isEmpty()) {
+        return false
+    }
+    if (decoded.size < MIN_SECRET_BYTES) {
+        return false
+    }
+
+    return true
+}
+
+private const val MIN_SECRET_BYTES = 10
+
+private fun padBase32(input: String): String {
+    val stripped = input.trimEnd('=')
+    val remainder = stripped.length % 8
+    if (remainder == 0) return stripped
+    val padLength = 8 - remainder
+    return stripped + "=".repeat(padLength)
 }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -2,6 +2,7 @@ package com.hegocre.nextcloudpasswords.utils
 
 import android.net.Uri
 import androidx.core.net.toUri
+import com.hegocre.nextcloudpasswords.R
 import dev.turingcomplete.kotlinonetimepassword.HmacAlgorithm
 import dev.turingcomplete.kotlinonetimepassword.HmacOneTimePasswordConfig
 import dev.turingcomplete.kotlinonetimepassword.HmacOneTimePasswordGenerator
@@ -85,13 +86,13 @@ data class OTP(
             val uri = url.toUri()
 
             if (uri.scheme?.equals("otpauth", ignoreCase = true) != true) {
-                throw IllegalArgumentException("Invalid OTP URL")
+                throw OtpParseException.InvalidUrl()
             }
 
             val type = when (uri.host?.lowercase()) {
                 "totp" -> Type.TOTP
                 "hotp" -> Type.HOTP
-                else -> throw IllegalArgumentException("Invalid OTP Type")
+                else -> throw OtpParseException.InvalidType()
             }
 
             val label = uri.encodedPath?.removePrefix("/") ?: ""
@@ -100,10 +101,10 @@ data class OTP(
             val accountName = (labelParts.getOrNull(1) ?: labelParts[0]).let { it.ifBlank { null } }
 
             val secret = uri.getQueryParameter("secret")
-                ?: throw IllegalArgumentException("Missing required 'secret' parameter")
+                ?: throw OtpParseException.MissingSecret()
 
             if (!Base32().isInAlphabet(secret)) {
-                throw IllegalArgumentException("Invalid 'secret' parameter")
+                throw OtpParseException.InvalidSecret()
             }
 
             val issuer = uri.getQueryParameter("issuer") ?: labelIssuer
@@ -113,7 +114,7 @@ data class OTP(
                 "sha256" -> Algorithm.SHA256
                 "sha512" -> Algorithm.SHA512
                 null -> Algorithm.SHA1
-                else -> throw IllegalArgumentException("Invalid OTP Algorithm")
+                else -> throw OtpParseException.InvalidAlgorithm()
             }
 
             val digits = uri.getQueryParameter("digits")?.toIntOrNull()
@@ -123,7 +124,7 @@ data class OTP(
                 ?.takeUnless { it < 0 }
 
             if (type == Type.HOTP && counter == null) {
-                throw IllegalArgumentException("HOTP requires a 'counter' parameter")
+                throw OtpParseException.MissingCounter()
             }
 
             val period = uri.getQueryParameter("period")?.toIntOrNull()
@@ -142,6 +143,15 @@ data class OTP(
         }
 
     }
+}
+
+sealed class OtpParseException(val stringResId: Int) : IllegalArgumentException() {
+    class InvalidUrl(resId: Int = R.string.error_invalid_otp_url) : OtpParseException(resId)
+    class InvalidType(resId: Int = R.string.error_invalid_otp_type) : OtpParseException(resId)
+    class MissingSecret(resId: Int = R.string.error_missing_secret) : OtpParseException(resId)
+    class InvalidSecret(resId: Int = R.string.error_invalid_secret) : OtpParseException(resId)
+    class InvalidAlgorithm(resId: Int = R.string.error_invalid_algorithm) : OtpParseException(resId)
+    class MissingCounter(resId: Int = R.string.error_missing_counter) : OtpParseException(resId)
 }
 
 fun String.formatOtp(chunkSize: Int? = null): String {

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -121,8 +121,8 @@ data class OTP(
                 else -> throw OtpParseException.InvalidAlgorithm()
             }
 
-            val digits = uri.getQueryParameter("digits")?.toIntOrNull()
-                ?.takeIf { it in 6..9 }
+            val digits = (uri.getQueryParameter("digits") ?: "6").toIntOrNull()
+                ?.takeIf { it in 6..9 } ?: throw OtpParseException.InvalidDigits()
 
             val counter = uri.getQueryParameter("counter")?.toLongOrNull()
                 ?.takeUnless { it < 0 }
@@ -131,16 +131,16 @@ data class OTP(
                 throw OtpParseException.MissingCounter()
             }
 
-            val period = uri.getQueryParameter("period")?.toIntOrNull()
-                ?.takeIf { it > 0 }
+            val period = (uri.getQueryParameter("period") ?: "30").toIntOrNull()
+                ?.takeIf { it > 0 } ?: throw OtpParseException.InvalidPeriod()
 
             return OTP(
                 secret = secret,
                 type = type,
                 algorithm = algorithm,
-                digits = digits ?: 6,
+                digits = digits,
                 counter = counter ?: 0L,
-                period = period ?: 30,
+                period = period,
                 issuer = issuer,
                 accountName = accountName
             )
@@ -156,6 +156,8 @@ sealed class OtpParseException(val stringResId: Int) : IllegalArgumentException(
     class InvalidSecret(resId: Int = R.string.error_invalid_secret) : OtpParseException(resId)
     class InvalidAlgorithm(resId: Int = R.string.error_invalid_algorithm) : OtpParseException(resId)
     class MissingCounter(resId: Int = R.string.error_missing_counter) : OtpParseException(resId)
+    class InvalidDigits(resId: Int = R.string.error_invalid_digits) : OtpParseException(resId)
+    class InvalidPeriod(resId: Int = R.string.error_invalid_period) : OtpParseException(resId)
 }
 
 fun String.formatOtp(chunkSize: Int? = null): String {

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -1,5 +1,7 @@
 package com.hegocre.nextcloudpasswords.utils
 
+import android.net.Uri
+import androidx.core.net.toUri
 import dev.turingcomplete.kotlinonetimepassword.HmacAlgorithm
 import dev.turingcomplete.kotlinonetimepassword.HmacOneTimePasswordConfig
 import dev.turingcomplete.kotlinonetimepassword.HmacOneTimePasswordGenerator
@@ -19,10 +21,10 @@ data class OTP(
     val type: String = Type.TOTP,
     val algorithm: String = Algorithm.SHA1,
     val digits: Int = 6,
-    val counter: Int = 0,
+    val counter: Long = 0,
     val period: Int = 30,
-    //val issuer: String? = null,
-    //val accountName: String? = null,
+    val issuer: String? = null,
+    val accountName: String? = null,
 ) {
     fun getCurrent(): Pair<String?, Long?> {
         val secret = Base32().decode(secret)
@@ -52,7 +54,7 @@ data class OTP(
                 secret = secret,
                 config = config
             )
-            return Pair(generator.generate(counter.toLong()), null)
+            return Pair(generator.generate(counter), null)
         }
 
         return Pair(null, null)
@@ -80,7 +82,63 @@ data class OTP(
         }
 
         fun fromUrl(url: String): OTP {
-            return OTP(secret = url)
+            val uri = url.toUri()
+
+            if (uri.scheme?.equals("otpauth", ignoreCase = true) != true) {
+                throw IllegalArgumentException("Invalid OTP URL")
+            }
+
+            val type = when (uri.host?.lowercase()) {
+                "totp" -> Type.TOTP
+                "hotp" -> Type.HOTP
+                else -> throw IllegalArgumentException("Invalid OTP Type")
+            }
+
+            val label = uri.encodedPath?.removePrefix("/") ?: ""
+            val labelParts = label.split(":", limit = 2).map { Uri.decode(it).trim() }
+            val labelIssuer = labelParts.getOrNull(1)?.let { labelParts[0] }
+            val accountName = (labelParts.getOrNull(1) ?: labelParts[0]).let { it.ifBlank { null } }
+
+            val secret = uri.getQueryParameter("secret")
+                ?: throw IllegalArgumentException("Missing required 'secret' parameter")
+
+            if (!Base32().isInAlphabet(secret)) {
+                throw IllegalArgumentException("Invalid 'secret' parameter")
+            }
+
+            val issuer = uri.getQueryParameter("issuer") ?: labelIssuer
+
+            val algorithm = when(uri.getQueryParameter("algorithm")?.lowercase()) {
+                "sha1" -> Algorithm.SHA1
+                "sha256" -> Algorithm.SHA256
+                "sha512" -> Algorithm.SHA512
+                null -> Algorithm.SHA1
+                else -> throw IllegalArgumentException("Invalid OTP Algorithm")
+            }
+
+            val digits = uri.getQueryParameter("digits")?.toIntOrNull()
+                ?.takeIf { it in 6..9 }
+
+            val counter = uri.getQueryParameter("counter")?.toLongOrNull()
+                ?.takeUnless { it < 0 }
+
+            if (type == Type.HOTP && counter == null) {
+                throw IllegalArgumentException("HOTP requires a 'counter' parameter")
+            }
+
+            val period = uri.getQueryParameter("period")?.toIntOrNull()
+                ?.takeIf { it > 0 }
+
+            return OTP(
+                secret = secret,
+                type = type,
+                algorithm = algorithm,
+                digits = digits ?: 6,
+                counter = counter ?: 0L,
+                period = period ?: 30,
+                issuer = issuer,
+                accountName = accountName
+            )
         }
 
     }

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -85,3 +85,15 @@ data class OTP(
 
     }
 }
+
+fun String.formatOtp(chunkSize: Int? = null): String {
+    val digitsOnly = this.filter { it.isDigit() }
+    val n = digitsOnly.length
+    val size = chunkSize ?: when {
+        n % 4 == 0 && n % 3 != 0 -> 4
+        n % 3 == 0 -> 3
+        else -> 3
+    }
+
+    return digitsOnly.chunked(size).joinToString(" ")
+}

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -61,6 +61,10 @@ data class OTP(
         return Pair(null, null)
     }
 
+    fun getNext(): OTP {
+        return this.copy(counter = counter + 1)
+    }
+
     companion object {
         const val CUSTOM_FIELD_LABEL = "client.ios.otp"
 

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/OTP.kt
@@ -1,0 +1,87 @@
+package com.hegocre.nextcloudpasswords.utils
+
+import dev.turingcomplete.kotlinonetimepassword.HmacAlgorithm
+import dev.turingcomplete.kotlinonetimepassword.HmacOneTimePasswordConfig
+import dev.turingcomplete.kotlinonetimepassword.HmacOneTimePasswordGenerator
+import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordConfig
+import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordGenerator
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+import org.apache.commons.codec.binary.Base32
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalSerializationApi::class)
+@JsonIgnoreUnknownKeys
+@Serializable
+data class OTP(
+    val secret: String,
+    val type: String = Type.TOTP,
+    val algorithm: String = Algorithm.SHA1,
+    val digits: Int = 6,
+    val counter: Int = 0,
+    val period: Int = 30,
+    //val issuer: String? = null,
+    //val accountName: String? = null,
+) {
+    fun getCurrent(): Pair<String?, Long?> {
+        val secret = Base32().decode(secret)
+
+        if (type == Type.TOTP) {
+            val config = TimeBasedOneTimePasswordConfig(
+                timeStep = period.toLong(),
+                timeStepUnit = TimeUnit.SECONDS,
+                codeDigits = digits,
+                hmacAlgorithm = Algorithm.toHmacAlgorithm(algorithm)
+            )
+            val generator = TimeBasedOneTimePasswordGenerator(
+                secret = secret,
+                config = config
+            )
+            val counter = generator.counter()
+            val endEpoch = generator.timeslotStart(counter + 1) - 1
+
+            return Pair(generator.generate(), endEpoch)
+        }
+        else if (type == Type.HOTP) {
+            val config = HmacOneTimePasswordConfig(
+                codeDigits = digits,
+                hmacAlgorithm = Algorithm.toHmacAlgorithm(algorithm)
+            )
+            val generator = HmacOneTimePasswordGenerator(
+                secret = secret,
+                config = config
+            )
+            return Pair(generator.generate(counter.toLong()), null)
+        }
+
+        return Pair(null, null)
+    }
+
+    companion object {
+        const val CUSTOM_FIELD_LABEL = "client.ios.otp"
+
+        object Type {
+            const val HOTP = "hotp"
+            const val TOTP = "totp"
+        }
+
+        object Algorithm {
+            const val SHA1 = "sha1"
+            const val SHA256 = "sha256"
+            const val SHA512 = "sha512"
+
+            fun toHmacAlgorithm(algorithm: String): HmacAlgorithm = when (algorithm) {
+                "sha1" -> HmacAlgorithm.SHA1
+                "sha256" -> HmacAlgorithm.SHA256
+                "sha512" -> HmacAlgorithm.SHA512
+                else -> HmacAlgorithm.SHA1
+            }
+        }
+
+        fun fromUrl(url: String): OTP {
+            return OTP(secret = url)
+        }
+
+    }
+}

--- a/app/src/main/java/com/hegocre/nextcloudpasswords/utils/PreferencesManager.kt
+++ b/app/src/main/java/com/hegocre/nextcloudpasswords/utils/PreferencesManager.kt
@@ -123,6 +123,12 @@ class PreferencesManager private constructor(context: Context) {
     fun setUseInlineAutofill(value: Boolean): Boolean =
         _encryptedSharedPrefs.edit().putBoolean("USE_INLINE_AUTOFILL", value).commit()
 
+    fun getCopyOTPOnAutofill(): Boolean =
+        _encryptedSharedPrefs.getBoolean("COPY_OTP_ON_AUTOFILL", false)
+
+    fun setCopyOTPOnAutofill(value: Boolean): Boolean =
+        _encryptedSharedPrefs.edit().putBoolean("COPY_OTP_ON_AUTOFILL", value).commit()
+
     fun getOfferCredentialSaving(): Boolean =
         _encryptedSharedPrefs.getBoolean("OFFER_CREDENTIAL_SAVING", true)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,8 +137,8 @@
     <string name="grant_permission">Grant permission</string>
     <string name="permission_required">Permission required</string>
     <string name="dialog_local_network_permission_message">The instance you are trying to access is on your local network. Starting from Android 17, you need to grant permission to the this app to access it. Do you want to proceed?</string>
-    <string name="copy_otp_preference_title">Copy OTP</string>
-    <string name="copy_otp_preference_subtitle">Copy the current code when autofilling a password with OTP</string>
+    <string name="copy_otp_preference_title">Copy TOTP</string>
+    <string name="copy_otp_preference_subtitle">Copy the current code when autofilling a password with Time-Based OTP</string>
     <string name="error_invalid_otp_url">Invalid OTP URL</string>
     <string name="error_invalid_otp_type">Invalid OTP type</string>
     <string name="error_missing_secret">Missing required \'secret\' parameter </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,7 +164,7 @@
     <string name="save_password">Save password</string>
     <string name="error_could_not_sync_counter">Could not sync counter. Please, remember to increment your counter again when online.</string>
     <string name="text_input_show_secret_toggle">Show secret</string>
-    <string name="generate_next_otp_htop">Generate next code</string>
+    <string name="generate_next_otp_hotp">Generate next code</string>
     <string name="error_invalid_digits">Invalid \'digits\' parameter</string>
     <string name="error_invalid_period">Invalid \'period\' parameter</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,4 +163,5 @@
     <string name="otp_invalid_counter_error">The counter is invalid</string>
     <string name="save_password">Save password</string>
     <string name="error_could_not_sync_counter">Could not sync counter. Please, remember to increment your counter again when online.</string>
+    <string name="text_input_show_secret_toggle">Show secret</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,4 +164,5 @@
     <string name="save_password">Save password</string>
     <string name="error_could_not_sync_counter">Could not sync counter. Please, remember to increment your counter again when online.</string>
     <string name="text_input_show_secret_toggle">Show secret</string>
+    <string name="generate_next_otp_htop">Generate next code</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,4 +137,6 @@
     <string name="grant_permission">Grant permission</string>
     <string name="permission_required">Permission required</string>
     <string name="dialog_local_network_permission_message">The instance you are trying to access is on your local network. Starting from Android 17, you need to grant permission to the this app to access it. Do you want to proceed?</string>
+    <string name="copy_otp_preference_title">Copy OTP</string>
+    <string name="copy_otp_preference_subtitle">Copy the current code when autofilling a password with OTP</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,4 +162,5 @@
     <string name="otp_invalid_period_error">The period is invalid</string>
     <string name="otp_invalid_counter_error">The counter is invalid</string>
     <string name="save_password">Save password</string>
+    <string name="error_could_not_sync_counter">Could not sync counter. Please, remember to increment your counter again when online.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,4 +165,6 @@
     <string name="error_could_not_sync_counter">Could not sync counter. Please, remember to increment your counter again when online.</string>
     <string name="text_input_show_secret_toggle">Show secret</string>
     <string name="generate_next_otp_htop">Generate next code</string>
+    <string name="error_invalid_digits">Invalid \'digits\' parameter</string>
+    <string name="error_invalid_period">Invalid \'period\' parameter</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,4 +139,27 @@
     <string name="dialog_local_network_permission_message">The instance you are trying to access is on your local network. Starting from Android 17, you need to grant permission to the this app to access it. Do you want to proceed?</string>
     <string name="copy_otp_preference_title">Copy OTP</string>
     <string name="copy_otp_preference_subtitle">Copy the current code when autofilling a password with OTP</string>
+    <string name="error_invalid_otp_url">Invalid OTP URL</string>
+    <string name="error_invalid_otp_type">Invalid OTP type</string>
+    <string name="error_missing_secret">Missing required \'secret\' parameter </string>
+    <string name="error_invalid_secret">Invalid \'secret\' parameter</string>
+    <string name="error_invalid_algorithm">Invalid OTP algorithm</string>
+    <string name="error_missing_counter">HOTP requires a \'counter\' parameter</string>
+    <string name="show_advanced_options">Show advanced options</string>
+    <string name="toggle_advanced_options">Toggle advanced options</string>
+    <string name="scan_qr_code">Scan QR code</string>
+    <string name="otp_secret">Secret</string>
+    <string name="otp_title">One-Time Password</string>
+    <string name="otp_type">Type</string>
+    <string name="otp_algorithm">Algorithm</string>
+    <string name="otp_type_totp">Time based (TOTP)</string>
+    <string name="otp_type_hotp">Counter based (HOTP)</string>
+    <string name="value_default">default</string>
+    <string name="otp_digits">Digits</string>
+    <string name="otp_period">Period</string>
+    <string name="otp_counter">Counter</string>
+    <string name="otp_invalid_digit_range_error">The digits value should be between 6 and 9</string>
+    <string name="otp_invalid_period_error">The period is invalid</string>
+    <string name="otp_invalid_counter_error">The counter is invalid</string>
+    <string name="save_password">Save password</string>
 </resources>


### PR DESCRIPTION
Implement 2FA OTP codes (TOTP and HOTP). Includes the following features:

- Store, show and edit OTP entries, compatible with the iOS app, and supporting all fields (secret, duration, length...)
- Scan QR code to import an OTP configuration
- Optionally, copy the OTP code when autofilling a password with OTP configured (only with TOTP)

Closes #117 